### PR TITLE
Adding campaign help mockups translation

### DIFF
--- a/ImperialCommander2/Assets/Resources/Languages/En/ui.json
+++ b/ImperialCommander2/Assets/Resources/Languages/En/ui.json
@@ -228,7 +228,10 @@
     "agendaImperialUC": "The Empire sees you as a threat worth stopping. Draw a card from the Imperial Mission Deck and put it into play. If it is a forced mission, immediately play that mission. If it is a side mission, it becomes an active side mission.",
     "agendaRebelUC": "The Empire uses its resources elsewhere. Nothing happens.",
     "xpUC": "XP",
-    "costUC": "Cost"
+    "costUC": "Cost",
+    "missionTypeMockupUC": "Mission Type",
+    "missionNameMockupUC": "Mission Name",
+    "itemMockupUC": "Tier 1"
   },
   "uiLogger": {
     "textLabel": "Text Message",

--- a/ImperialCommander2/Assets/Resources/Languages/Fr/ui.json
+++ b/ImperialCommander2/Assets/Resources/Languages/Fr/ui.json
@@ -228,7 +228,10 @@
     "agendaImperialUC": "L'Empire vous considère comme une menace qu'il faut arrêter. Tirez une carte de la pioche des missions impériales et mettez-la en jeu. Si c'est une mission forcée, jouez immédiatement cette mission. Si c'est une mission annexe, elle devient une mission annexe active.",
     "agendaRebelUC": "L'Empire utilise ses ressources ailleurs. Rien ne se passe.",
     "xpUC": "XP",
-    "costUC": "Coût"
+    "costUC": "Coût",
+    "missionTypeMockupUC": "Type de Mission",
+    "missionNameMockupUC": "Nom de la Mission",
+    "itemMockupUC": "Échelon 1"
   },
   "uiLogger": {
     "textLabel": "Message texte",

--- a/ImperialCommander2/Assets/Scenes/Campaign.unity
+++ b/ImperialCommander2/Assets/Scenes/Campaign.unity
@@ -6807,6 +6807,9 @@ MonoBehaviour:
   villainsUC: {fileID: 1393860849}
   alliesUC: {fileID: 2002937883}
   xpUC: {fileID: 691146656}
+  missionTypeMockupUC: {fileID: 1050871373}
+  missionNameMockupUC: {fileID: 1644581259}
+  itemMockupUC: {fileID: 427034973}
 --- !u!4 &516629872
 Transform:
   m_ObjectHideFlags: 0

--- a/ImperialCommander2/Assets/Scripts/LanguageControllers/CampaignLanguageController.cs
+++ b/ImperialCommander2/Assets/Scripts/LanguageControllers/CampaignLanguageController.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 
 public class CampaignLanguageController : MonoBehaviour
 {
-	public TextMeshProUGUI campaignNameUC, creditsUC, fameUC, awardsUC, itemsUC, rewardsUC, villainsUC, alliesUC, xpUC;
+	public TextMeshProUGUI campaignNameUC, creditsUC, fameUC, awardsUC, itemsUC, rewardsUC, villainsUC, alliesUC, xpUC, missionTypeMockupUC, missionNameMockupUC, itemMockupUC;
 
 	public void SetTranslatedUI()
 	{
@@ -19,5 +19,8 @@ public class CampaignLanguageController : MonoBehaviour
 		villainsUC.text = ui.villainsUC;
 		alliesUC.text = ui.alliesUC;
 		xpUC.text = ui.xpUC + ":";
+		missionTypeMockupUC.text = ui.missionTypeMockupUC;
+		missionNameMockupUC.text = ui.missionNameMockupUC;
+		itemMockupUC.text = ui.itemMockupUC;
 	}
 }

--- a/ImperialCommander2/Assets/Scripts/LanguageControllers/UILanguage.cs
+++ b/ImperialCommander2/Assets/Scripts/LanguageControllers/UILanguage.cs
@@ -63,7 +63,7 @@ public class UIDeploymentGroups
 
 public class UICampaign
 {
-	public string threatInfoUC, modeIntroductionUC, modeStoryUC, modeSideUC, forcedUC, modeInterludeUC, modeFinaleUC, campaignNameUC, customCampaign, addForcedMissionUC, tierUC, selectMissionUC, customUC, creditsUC, fameUC, awardsUC, campaignSetup, itemsUC, rewardsUC, villainsUC, alliesUC, threat, agendaUC, modifyUC, removeUC, otherUC, campaignUC, generalUC, heroUC, personalUC, campaignSetupUC, campaignDescriptionUC, sagaDescriptionUC, classicDescriptionUC, agendaMission, agendaImperialUC, agendaRebelUC, xpUC, costUC;
+	public string threatInfoUC, modeIntroductionUC, modeStoryUC, modeSideUC, forcedUC, modeInterludeUC, modeFinaleUC, campaignNameUC, customCampaign, addForcedMissionUC, tierUC, selectMissionUC, customUC, creditsUC, fameUC, awardsUC, campaignSetup, itemsUC, rewardsUC, villainsUC, alliesUC, threat, agendaUC, modifyUC, removeUC, otherUC, campaignUC, generalUC, heroUC, personalUC, campaignSetupUC, campaignDescriptionUC, sagaDescriptionUC, classicDescriptionUC, agendaMission, agendaImperialUC, agendaRebelUC, xpUC, costUC, missionTypeMockupUC, missionNameMockupUC, itemMockupUC;
 
 	public string[] missionTypeStrings;
 


### PR DESCRIPTION
Adding campaign help mockups translation.

I'm sending a PR for the translator app as well.

(Note: this is to address the issue I previously reported here : https://github.com/GlowPuff/ImperialCommander2/issues/67)