### PR TITLE
Modifying Min font size for the item tier toggle in the campaign manager

### DIFF
--- a/ImperialCommander2/Assets/Prefabs/Campaign/MissionItemPrefab.prefab
+++ b/ImperialCommander2/Assets/Prefabs/Campaign/MissionItemPrefab.prefab
@@ -2640,7 +2640,7 @@ MonoBehaviour:
   m_fontSizeBase: 20
   m_fontWeight: 400
   m_enableAutoSizing: 1
-  m_fontSizeMin: 18
+  m_fontSizeMin: 16
   m_fontSizeMax: 18
   m_fontStyle: 1
   m_HorizontalAlignment: 2

--- a/ImperialCommander2/Assets/Scenes/Campaign.unity
+++ b/ImperialCommander2/Assets/Scenes/Campaign.unity
@@ -5810,7 +5810,7 @@ MonoBehaviour:
   m_fontSizeBase: 20
   m_fontWeight: 400
   m_enableAutoSizing: 1
-  m_fontSizeMin: 18
+  m_fontSizeMin: 16
   m_fontSizeMax: 18
   m_fontStyle: 1
   m_HorizontalAlignment: 2


### PR DESCRIPTION
Modifying the min font size (only from 18 to 16) for the item toggle text (_"Tier 1"_) in the campaign manager.
This will help to make the text more readable for French translation.
Based on my tests, it should **not** change other languages (except DE & IT, but it should actually improve their display as well).

Examples before:

![image](https://github.com/GlowPuff/ImperialCommander2/assets/170425011/c1f05b6d-9537-438e-ab24-365a2434872a) ![image](https://github.com/GlowPuff/ImperialCommander2/assets/170425011/7529c1b0-f43f-44c8-a1bb-170b1225ee67) ![image](https://github.com/GlowPuff/ImperialCommander2/assets/170425011/637798ff-8092-432e-9339-379ee76ae5d8)

after:

![image](https://github.com/GlowPuff/ImperialCommander2/assets/170425011/27b144db-88b6-46a1-a878-7d2aa0d3e115) ![image](https://github.com/GlowPuff/ImperialCommander2/assets/170425011/1b178587-9dda-4ccf-a344-7b81e883b138) ![image](https://github.com/GlowPuff/ImperialCommander2/assets/170425011/5b37359b-96a1-47b5-857c-809d1eb63e0a)
