### PR TITLE
Changing round limit width settings to accommodate more translations.

### DIFF
--- a/ImperialCommander2/Assets/Prefabs/settings screen.prefab
+++ b/ImperialCommander2/Assets/Prefabs/settings screen.prefab
@@ -862,7 +862,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 250, y: 65}
+  m_SizeDelta: {x: 600, y: 65}
   m_Pivot: {x: 0, y: 0.5}
 --- !u!222 &3905000581663087592
 CanvasRenderer:
@@ -899,7 +899,7 @@ MonoBehaviour:
     m_BestFit: 1
     m_MinSize: 10
     m_MaxSize: 40
-    m_Alignment: 3
+    m_Alignment: 4
     m_AlignByGeometry: 1
     m_RichText: 1
     m_HorizontalOverflow: 0
@@ -1196,7 +1196,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 0, y: 0.5}
   m_AnchoredPosition: {x: 65.35, y: -0.000012398}
-  m_SizeDelta: {x: 234.65, y: 100}
+  m_SizeDelta: {x: 240, y: 100}
   m_Pivot: {x: 0, y: 0.5}
 --- !u!222 &5807938004019195579
 CanvasRenderer:
@@ -2351,7 +2351,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 0, y: 0.5}
   m_AnchoredPosition: {x: 65.35, y: -0.000012398}
-  m_SizeDelta: {x: 134.65, y: 100}
+  m_SizeDelta: {x: 210, y: 100}
   m_Pivot: {x: 0, y: 0.5}
 --- !u!222 &4523876943218746960
 CanvasRenderer:
@@ -2967,7 +2967,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 200, y: 100}
+  m_SizeDelta: {x: 145, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &3489833479920056721
 MonoBehaviour:
@@ -6533,7 +6533,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 0, y: 0.5}
   m_AnchoredPosition: {x: 65.35, y: -0.000012398}
-  m_SizeDelta: {x: 134.65, y: 100}
+  m_SizeDelta: {x: 155, y: 100}
   m_Pivot: {x: 0, y: 0.5}
 --- !u!222 &1140993876458052537
 CanvasRenderer:
@@ -6883,7 +6883,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 300, y: 100}
+  m_SizeDelta: {x: 230, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &5857736203027005044
 MonoBehaviour:


### PR DESCRIPTION
Changing round limit width settings to accommodate more language translations.
It should not change English to much (only shifting the buttons a little).

Please feel free to decline this change if you think it's not appropriate.

Images speaking louder than words:

_Languages benefiting from this change:_

 - French (top: before change, down: after change):
![image](https://github.com/GlowPuff/ImperialCommander2/assets/170425011/c218c77a-6aac-4670-91af-009008267717)

- Russian (top: before change, down: after change):
![image](https://github.com/GlowPuff/ImperialCommander2/assets/170425011/93cdaf99-c2cc-448b-841c-0b889ddbe4c6)

_Other languages (no change to their display, but a little impacted by the buttons shifting):_

- English (top: before change, down: after change):
![image](https://github.com/GlowPuff/ImperialCommander2/assets/170425011/cf645058-16fe-497b-a60a-e33927da8dc7)

- German (top: before change, down: after change):
![image](https://github.com/GlowPuff/ImperialCommander2/assets/170425011/d97b08ad-8f2a-4db8-ad2d-209d3074ca17)
