### PR TITLE
Changing figure packs max font size to accommodate more translations.

### DIFF
--- a/ImperialCommander2/Assets/Scenes/Title.unity
+++ b/ImperialCommander2/Assets/Scenes/Title.unity
@@ -6931,7 +6931,7 @@ MonoBehaviour:
     m_FontStyle: 0
     m_BestFit: 1
     m_MinSize: 10
-    m_MaxSize: 40
+    m_MaxSize: 30
     m_Alignment: 4
     m_AlignByGeometry: 1
     m_RichText: 1
@@ -35997,7 +35997,7 @@ MonoBehaviour:
     m_FontStyle: 0
     m_BestFit: 1
     m_MinSize: 10
-    m_MaxSize: 40
+    m_MaxSize: 30
     m_Alignment: 4
     m_AlignByGeometry: 1
     m_RichText: 1
@@ -45864,7 +45864,7 @@ MonoBehaviour:
     m_FontStyle: 0
     m_BestFit: 1
     m_MinSize: 10
-    m_MaxSize: 40
+    m_MaxSize: 30
     m_Alignment: 4
     m_AlignByGeometry: 1
     m_RichText: 1
@@ -56366,7 +56366,7 @@ MonoBehaviour:
     m_FontStyle: 0
     m_BestFit: 1
     m_MinSize: 10
-    m_MaxSize: 40
+    m_MaxSize: 30
     m_Alignment: 4
     m_AlignByGeometry: 1
     m_RichText: 1
@@ -57798,7 +57798,7 @@ MonoBehaviour:
     m_FontStyle: 0
     m_BestFit: 1
     m_MinSize: 10
-    m_MaxSize: 40
+    m_MaxSize: 30
     m_Alignment: 4
     m_AlignByGeometry: 1
     m_RichText: 1
@@ -57877,7 +57877,7 @@ MonoBehaviour:
     m_FontStyle: 0
     m_BestFit: 1
     m_MinSize: 10
-    m_MaxSize: 40
+    m_MaxSize: 30
     m_Alignment: 4
     m_AlignByGeometry: 1
     m_RichText: 1
@@ -62879,7 +62879,7 @@ MonoBehaviour:
     m_FontStyle: 0
     m_BestFit: 1
     m_MinSize: 10
-    m_MaxSize: 40
+    m_MaxSize: 30
     m_Alignment: 4
     m_AlignByGeometry: 1
     m_RichText: 1
@@ -66260,7 +66260,7 @@ MonoBehaviour:
     m_FontStyle: 0
     m_BestFit: 1
     m_MinSize: 10
-    m_MaxSize: 40
+    m_MaxSize: 30
     m_Alignment: 4
     m_AlignByGeometry: 1
     m_RichText: 1


### PR DESCRIPTION
Changing figure packs max font size to accommodate more language translations.
For several languages, currently, the letters protrude from the boxes.

Please feel free to decline this change if you think it's not appropriate.

Images speaking louder than words:

_Languages benefiting from this change (French, German, Spanish, Russian):_

Before change:
![image](https://github.com/GlowPuff/ImperialCommander2/assets/170425011/fef0edd2-4116-4af9-91af-89424b2bcf76)

After change:
![image](https://github.com/GlowPuff/ImperialCommander2/assets/170425011/74a052b5-6766-4b26-a090-fe348416e424)

_English version display change (before change: left, after change: right):_
![image](https://github.com/GlowPuff/ImperialCommander2/assets/170425011/225b3008-c310-461f-83c6-b09ece3a5eef)

