### PR TITLE
Adding French translation for Lothal

### DIFF
--- a/ImperialCommander2/Assets/Resources/Languages/Fr/Missions/Lothal/LOTHAL1_FR.json
+++ b/ImperialCommander2/Assets/Resources/Languages/Fr/Missions/Lothal/LOTHAL1_FR.json
@@ -1,0 +1,843 @@
+{
+  "languageID": "French (FR)",
+  "missionProperties": {
+    "missionName": "Appel à l'action",
+    "missionDescription": "",
+    "missionInfo": "",
+    "campaignName": "Tyrans de Lothal",
+    "startingObjective": "",
+    "repositionOverride": "Bloquer l'accès à la cargaison et au point d'extraction.",
+    "additionalMissionInfo": null
+  },
+  "events": [
+    {
+      "eventName": "Open Crate 1",
+      "GUID": "2dec36b9-ce77-4bf6-8c35-9489e6573609",
+      "eventText": "Vous fouillez la caisse et prenez ce qui vous semble utile.\r\n\r\nPiochez une carte Ravitaillement. Vous gagnez 1 médipack. Récupérez ce pion.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Crate1",
+              "GUID": "378fe5d7-8a8e-49e2-93cc-d055de90bad2",
+              "theText": "Une vieille caisse de ravitaillement.",
+              "buttonList": [
+                {
+                  "GUID": "f31466a9-6cf8-4a35-b3b1-bbca25d6f2b7",
+                  "theText": "{A} Ouvrir"
+                }
+              ]
+            }
+          ],
+          "GUID": "8eb6c4bb-fd64-4ae8-9b6d-a5ba3f737e6a",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "Open Crate 2",
+      "GUID": "74bbaee9-47db-48c2-b09c-7d0940adf6ab",
+      "eventText": "Vous fouillez la caisse et prenez ce qui vous semble utile.\r\n\r\nPiochez une carte Ravitaillement. Vous gagnez 1 médipack. Récupérez ce pion.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Crate2",
+              "GUID": "ff97f117-4293-4bc5-8fc9-99c8faad157c",
+              "theText": "Une vieille caisse de ravitaillement.",
+              "buttonList": []
+            }
+          ],
+          "GUID": "a6f06d59-b18c-465a-acc1-85db4a122e25",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "Mission Briefing",
+      "GUID": "edc56ae0-7e4f-4ecd-9176-26e69bfd835a",
+      "eventText": "Vous interceptez la cargaison d'armes impériales au moment où son porteur se fraye un chemin à travers les marchés de Lothal. Les infos de votre contact étaient fiables. Vos veines sont saturées d'adrénaline et vous priez pour qu'il arrive à temps au point d'extraction.\r\n\r\n{-} Déployez les héros sur la case bleue en surbrillance.\r\n{-} Quand un héros se replie, il est neutralisé à la place. Quand il est activé, il ne reçoit que 1 action, qu'il ne peut utiliser que pour se déplacer.",
+      "eventActions": [
+        {
+          "tbText": "La cargaison est lourde, mais le traîneau à répulseurs permet au moins de la déplacer.",
+          "GUID": "61789c71-c004-42fd-bd1c-d8bee072fedd",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Shipment",
+              "GUID": "5368912a-0247-457c-a6a7-53eb986ff2f5",
+              "theText": null,
+              "buttonList": []
+            }
+          ],
+          "GUID": "1b8e1dde-3178-4b37-ab2f-b3525174ce8f",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        },
+        {
+          "tbText": "{-} Le pion Mission Impérial représente la cargaison. Une fois pendant son activation, un héros sur la cargaison ou adjacent à la cargaison peut la pousser de 1 case.",
+          "GUID": "5175e5bf-9801-4f56-9e2c-8e8265bb7f9f",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "tbText": "Votre contact vous a donné des coordonnées très précises de l'endroit où vous devez apporter la cargaison.",
+          "GUID": "3ee188f9-43d6-4bcd-855f-b17c32c94af4",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Shipment",
+              "GUID": "1f8f0b73-beaf-4486-869c-4f5304ca2197",
+              "theText": null,
+              "buttonList": []
+            },
+            {
+              "entityName": "Extraction Point",
+              "GUID": "36bb4ce6-72c9-4248-9681-7c9386c6ece5",
+              "theText": "Le vaisseau de votre contact vous attend ici.\r\n\r\n{-} Quand la cargaison entre sur cette case, cliquez sur \"Extraire la cargaison\".",
+              "buttonList": [
+                {
+                  "GUID": "19f99a4a-07f4-44a0-804b-0300e95a7e7a",
+                  "theText": "Extraire la cargaison"
+                }
+              ]
+            }
+          ],
+          "GUID": "93878fae-0733-4dec-b799-ac870d2b3024",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        },
+        {
+          "tbText": "{-} Le pion Mission Rebelle représente le point d'extraction. Quand la cargaison entre sur le point d'extraction, cliquez sur le pion et sélectionnez \"Extraire la cargaison\".\r\n{-} La mission évolue quand la cargaison est extraite.\r\n{-} Si la limite de Rounds est activée, la mission s'achève à la fin du round 4 si la cargaison n'est pas extraite, à la fin du round 6, ou quand tous les héros sont blessés.",
+          "GUID": "049ac23d-9fe8-497a-9d28-dfc5bc7d7778",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "shortText": "Apporter la cargaison au point d'extraction.",
+          "longText": null,
+          "GUID": "d6db4f3a-3883-4f20-ac31-9d9151a54b3c",
+          "eventActionType": 2,
+          "eaName": "Change Objective"
+        },
+        {
+          "theText": "{-} Quand un héros se replie, il est neutralisé à la place. Quand il est activé, il ne reçoit que 1 action, qu'il ne peut utiliser que pour se déplacer.\r\n{-} Le pion Mission Impérial représente la cargaison. Une fois pendant son activation, un héros sur la cargaison ou adjacent à la cargaison peut la pousser de 1 case.\r\n{-} Le pion Mission Rebelle représente le point d'extraction. Quand la cargaison entre sur le point d'extraction, cliquez sur le pion et sélectionnez \"Extraire la cargaison\".\r\n{-} La mission évolue quand la cargaison est extraite.\r\n{-} Si la limite de Rounds est activée, la mission s'achève à la fin du round 4 si la cargaison n'est pas extraite, à la fin du round 6, ou quand tous les héros sont blessés.",
+          "GUID": "a5de9754-b29b-4604-99fb-0cd8e527f0e3",
+          "eventActionType": 1,
+          "eaName": "Change Mission Info"
+        }
+      ]
+    },
+    {
+      "eventName": "End of Mission - Rebels win",
+      "GUID": "69b80fad-5e0e-46cd-a70e-defa45de4db6",
+      "eventText": "Une navette survole votre zone. Un homme vous aide à passer par la trappe à l'arrière du vaisseau. Un masque vert couvre la moitié supérieure de son visage. \"Bienvenue à bord du Phantom.\"\r\n\r\n{-} Les Rebelles remportent la mission !\r\n{-} Les joueurs Rebelles choisissent l'un des leurs, qui reçoit la carte Récompense \"Leader de la cellule nova\".",
+      "eventActions": [
+        {
+          "mainText": "Jouez-vous cette mission dans le cadre de la mini-campagne \"Tyrans de Lothal\" ?",
+          "buttonList": [
+            {
+              "GUID": "0d3e12e7-35ea-432e-878f-f6abd45b6040",
+              "theText": "Oui"
+            },
+            {
+              "GUID": "09e4d0ff-835d-4a68-a917-3f46d381f47a",
+              "theText": "Non"
+            }
+          ],
+          "GUID": "fa160c96-ff1c-4306-ad5f-f40d51ef9331",
+          "eventActionType": 5,
+          "eaName": "Question Prompt"
+        }
+      ]
+    },
+    {
+      "eventName": "End of Mission - Rebels lose",
+      "GUID": "9e960fce-d271-468c-8d6c-233bc752aa52",
+      "eventText": "Des explosions retentissent autour de vous en vous épargnant par miracle. Une silhouette en armure mandalorienne lance quelques grenades de plus depuis une navette, avant de vous lancer une corde.\r\n\r\n{-} Les Rebelles perdent la mission.",
+      "eventActions": [
+        {
+          "mainText": "Jouez-vous cette mission dans le cadre de la mini-campagne \"Tyrans de Lothal\" ?",
+          "buttonList": [
+            {
+              "GUID": "ac7d367e-25a1-4f92-b311-81681fb5926e",
+              "theText": "Oui"
+            },
+            {
+              "GUID": "f4416ff4-b2cc-4d0a-a7c5-16f1a4826315",
+              "theText": "Non"
+            }
+          ],
+          "GUID": "922d0b18-3b9c-4426-b8b1-9d79afd7d873",
+          "eventActionType": 5,
+          "eaName": "Question Prompt"
+        }
+      ]
+    },
+    {
+      "eventName": "Mini campaign Win",
+      "GUID": "1fb0c0b1-7388-42f6-9c4c-801de27f03a5",
+      "eventText": "\"Ezra, ramène-nous au Ghost\", demande l'homme qui porte un masque à un autre, plus jeune, aux commandes de la navette. \"Je m'appelle Kanan Jarrus. Je ne savais pas qu'il restait encore des rebelles sur Lothal\".\r\n\r\nVous lui expliquez que vous venez tout juste de rejoindre le combat contre l'Empire. \"Vous vous apprêtez à arpenter un chemin difficile\", finit-il par répondre, \"mais les Spectres seront vos alliés. Nous vous montrerons ce que vous avez besoin de savoir.\"\r\n\r\n\"Seulement, ne croyez pas que ce sera facile\", ajoute Ezra. \"Kanan a pour habitude d'enseigner à la dure\".\r\n\r\n{-} Chaque héros reçoit 2 XP.\r\n{-} Les héros reçoivent 300 crédits par héros.\r\n{-} Les héros reçoivent <color=\"red\">Kanan Jarrus</color> (Spectre-l), <color=\"red\">Zeb Orrelios</color> (Spectre-4), <color=\"red\">Sabine Wren</color> (Spectre-5), et <color=\"red\">Ezra Bridger</color> (Spectre-6) en tant qu'alliés. Les héros reçoivent également <color=\"red\">Hera Syndulla</color> (Spectre-2) et <color=\"red\">C1-10P</color> (\"Chopper\") s'ils possèdent l'extension de figurines allié Hera Syndulla et C1-10P.",
+      "eventActions": [
+        {
+          "mainText": "Veuillez sélectionner la bonne option :\r\n\r\n{-} Campagne étendue : vous jouez la mini-campagne étendue avec l'extension de figurine \"Hondo Ohnaka\".\r\n{-} Mini-campagne : vous jouez la mini-campagne \"Tyrans de Lothal\" sans l'extension de figurine.",
+          "buttonList": [
+            {
+              "GUID": "581b61ab-b1cf-4cfc-b5e8-d57b5ee59671",
+              "theText": "Campagne étendue"
+            },
+            {
+              "GUID": "83251f70-a773-4fae-9b92-a4e91d494b5f",
+              "theText": "Mini-campagne"
+            }
+          ],
+          "GUID": "d93f8f65-094a-440f-bd2c-2849d9099137",
+          "eventActionType": 5,
+          "eaName": "Question Prompt"
+        }
+      ]
+    },
+    {
+      "eventName": "Mini campaign Defeat",
+      "GUID": "ee9e6f21-9b9f-47ca-b982-44b59453a837",
+      "eventText": "\"La subtilité ce n'est pas vraiment votre truc, c'est ça hein ?\" demande la fille. \"Je m'appelle Sabine. Lui, c'est Zeb.\" Elle vous indique le grand Lasat engoncé dans le siège du pilote. \"On y va !\"\r\n\r\nZeb la fusille du regard. \"On ne va pas quand même pas les ramener à bord du Ghost\", grogne-t-il en serrant les dents. \"Ils n'ont probablement aucune idée de ce qu'ils sont en train de faire.\"\r\n\r\nSabine s'affale dans le siège du copilote. \"Il faut bien qu'ils apprennent d'une manière ou d'une autre ! Et qui pourrait leur enseigner mieux que nous ?\"\r\n\r\n{-} Chaque héros reçoit 2 XP.\r\n{-} Les héros reçoivent 300 crédits par héros.\r\n{-} Les héros reçoivent <color=\"red\">Kanan Jarrus</color> (Spectre-l), <color=\"red\">Zeb Orrelios</color> (Spectre-4), <color=\"red\">Sabine Wren</color> (Spectre-5), et <color=\"red\">Ezra Bridger</color> (Spectre-6) en tant qu'alliés. Les héros reçoivent également <color=\"red\">Hera Syndulla</color> (Spectre-2) et <color=\"red\">C1-10P</color> (\"Chopper\") s'ils possèdent l'extension de figurines allié Hera Syndulla et C1-10P.",
+      "eventActions": [
+        {
+          "mainText": "Veuillez sélectionner la bonne option :\r\n\r\n{-} Campagne étendue : vous jouez la mini-campagne étendue avec l'extension de figurine \"Hondo Ohnaka\".\r\n{-} Mini-campagne : vous jouez la mini-campagne \"Tyrans de Lothal\" sans l'extension de figurine.",
+          "buttonList": [
+            {
+              "GUID": "93d71bef-afed-4d05-9469-8942ae8aad6b",
+              "theText": "Campagne étendue"
+            },
+            {
+              "GUID": "4497ea51-871e-4c2d-85fa-b8a6b180d291",
+              "theText": "Mini-campagne"
+            }
+          ],
+          "GUID": "c47a75a7-d9d7-4f27-ab49-39ee814934b8",
+          "eventActionType": 5,
+          "eaName": "Question Prompt"
+        }
+      ]
+    },
+    {
+      "eventName": "No campaign",
+      "GUID": "8fe1b24a-487b-46a0-9e81-94329508e0dc",
+      "eventText": "{-} Chaque héros reçoit 1 XP.\r\n{-} Les héros reçoivent 100 crédits par héros.",
+      "eventActions": []
+    },
+    {
+      "eventName": "Extended campaign 1",
+      "GUID": "2f95d44b-fe49-4580-aed5-8b4db04f67d8",
+      "eventText": "Tandis que le Phantom vous transporte jusqu'à votre vaisseau, votre comlink se manifeste. La voix désincarnée de votre contact local, N-4M, se fait entendre. J'aurais dû examiner M. Ohnaka plus scrupuleusement, concède-t-il. Le vocabulateur du droïde bourdonne et bégaye. \"Heureusement, mes informateurs ont aperçu M. Ohnaka embarquer sur un vaisseau en partance. Je peux vous transmettre sa probable destination.\"\r\n\r\nVous informez vos sauveurs que vous avez besoin de faire un détour avant de rencontrer le reste de leur groupe. Ils vous proposent alors d'envoyer quelqu'un pour vous porter assistance. Vous avez une affaire en suspens avec Hondo Ohnaka…\r\n\r\n{-} La prochaine mission active est \"Le subterfuge du pirate\" (extension de figurine antagoniste Hondo Ohnaka).",
+      "eventActions": []
+    },
+    {
+      "eventName": "Regular mini campaign",
+      "GUID": "5912594d-6f76-449a-8572-5004d336bdd9",
+      "eventText": "Vous vous amarrez à un Cargo VCX-100. Une fois à bord, vous rencontrez le reste de l'équipe, et la Capitaine Hera Syndulla. \"Toute l'aide que nous pourrons recevoir sera la bienvenue\", confirme-t-elle, \"et puisque vous avez gagné la confiance de mon équipe, je vous confie aussi la mienne. Nous avons plus de travail à accomplir que de bras pour le faire.\"\r\n\r\n\"Avez-vous entendu parler du Grand Amiral Thrawn\" ? Il vient de mettre tout le secteur en alerte rouge. On peut à peine bouger le petit doigt. Elle s'appuie contre la petite table au milieu de la pièce. \"Nous avons des alliés sur Seelos, Wolfe et Gregor. Ils ont récupéré des codes Impériaux sur un marcheur volé, mais ils ont besoin d'aide pour échapper à l'Empire. Nous avons également une piste qui nous mène à la cachette d'un vieux contrebandier sur Dévaron. Elle contient les cartes des meilleures routes de contrebande du secteur. Si nous arrivons à les obtenir, nous pourrons éviter les patrouilles Impériales et il nous sera même possible de nous passer des codes.\" Elle se tourne vers vous. \"Si vous pouvez nous aider à accomplir ces missions, j'enverrai un membre de mon équipage avec vous.\"\r\n\r\n{-} Les héros choisissent collectivement s'ils souhaitent aider Wolffe et Gregor ou s'ils préfèrent fouiller la cachette du contrebandier.\r\n{-} Si les héros choisissent d'aider Wolffe et Gregor, la prochaine mission active est \"Les Dunes de Seelos\".\r\n{-} Si les héros choisissent de fouiller la cachette du contrebandier, la prochaine mission active est \"Duel sur Dévaron\".",
+      "eventActions": []
+    },
+    {
+      "eventName": "Just Business",
+      "GUID": "b0060326-f45b-4228-b15f-23ce78756a6a",
+      "eventText": "Votre contact, Hondo Ohnaka, sourit jusqu'aux oreilles tandis qu'il hisse la cargaison à bord de son vaisseau. \"Bien joué, mes amis !\"\r\nLe vaisseau commence à décoller avant que vous ne puissiez embarquer. \"Malheureusement, on m'a fait une meilleure offre.\" Hondo pointe son blaster sur vous alors que des Impériaux arrivent en renfort.\r\n\r\n{-} Défaussez la cargaison.",
+      "eventActions": [
+        {
+          "enemyName": null,
+          "customText": "",
+          "modification": "+*1* Santé",
+          "repositionInstructions": "",
+          "GUID": "ff06cb3b-b18f-4033-bdf6-1e5c642b6248",
+          "eventActionType": 6,
+          "eaName": "Deploy: DG086/Hondo Ohnaka"
+        },
+        {
+          "enemyName": null,
+          "customText": "",
+          "modification": null,
+          "repositionInstructions": "",
+          "GUID": "55f717fa-8c0a-4318-a57c-82e3ad8e01bd",
+          "eventActionType": 6,
+          "eaName": "Deploy: DG057/Death Trooper"
+        },
+        {
+          "enemyName": null,
+          "customText": "",
+          "modification": null,
+          "repositionInstructions": "",
+          "GUID": "f0eecc17-35eb-44f0-8377-00969e7dd3d6",
+          "eventActionType": 6,
+          "eaName": "Deploy: DG005/Imperial Officer"
+        },
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Extraction Point",
+              "GUID": "1b390272-f828-4ce5-abf6-522a18519eab",
+              "theText": "Le vaisseau de votre contact vous attend ici.\r\n\r\n{-} Quand la cargaison entre sur cette case, cliquez sur \"Extraire la cargaison\".",
+              "buttonList": [
+                {
+                  "GUID": "b14be948-cfc3-4b12-bba7-fd73358145ed",
+                  "theText": "Extraire la cargaison"
+                }
+              ]
+            },
+            {
+              "entityName": "DP Yellow 1",
+              "GUID": "0c05fbb3-6d10-4dc2-afb7-5f2bfbbf3c4e",
+              "theText": null,
+              "buttonList": []
+            },
+            {
+              "entityName": "DP Yellow 2",
+              "GUID": "dd8bdb66-66e7-43f0-a770-c2da320463e3",
+              "theText": null,
+              "buttonList": []
+            },
+            {
+              "entityName": "DP Green 1",
+              "GUID": "83777b67-baeb-40f4-8aed-6b42dfcb54aa",
+              "theText": null,
+              "buttonList": []
+            },
+            {
+              "entityName": "DP Green 2",
+              "GUID": "33dda837-3a41-4976-bf43-2d45a2013fa0",
+              "theText": null,
+              "buttonList": []
+            },
+            {
+              "entityName": "DP Green 3",
+              "GUID": "ebb911a2-d6f3-49ea-9854-58d4ec5bba85",
+              "theText": null,
+              "buttonList": []
+            }
+          ],
+          "GUID": "a1594c7e-6493-4280-a37d-5786bf5e4443",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        },
+        {
+          "tbText": "À travers les interférences, vous entendez une voix dans votre com. \"Tous les ennemis de l'Empire sont nos amis. Tenez bon, nous arrivons !\"\r\n\r\nAu loin, vous pouvez apercevoir un vaisseau qui descend dans l'atmosphère de Lothal en direction des champs parsemés de monticules.",
+          "GUID": "23956a87-99c9-4c58-89d4-3399a3f20942",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "tbText": "\"Nous n'arrivons pas à déterminer votre position\", dit la voix dans votre com. \"Il devrait y avoir de vieilles balises en bas. Trouvez-les et allumez-en une, vous n'aurez plus qu'à tenir jusqu'à ce qu'on arrive !\"",
+          "GUID": "42a00ded-0412-4aed-9ec5-60831a2ea12e",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Flare 1",
+              "GUID": "f27755d0-fa37-4167-ba6c-7da35b60ff14",
+              "theText": "Une vieille balise est cachée dans les hautes herbes.\r\n\r\n{-} Un héros indemne peut interagir avec balise pour l'allumer.",
+              "buttonList": [
+                {
+                  "GUID": "6e729cd1-5a06-4969-be44-499291a063a3",
+                  "theText": "{A} Allumer la balise"
+                }
+              ]
+            },
+            {
+              "entityName": "Flare 2",
+              "GUID": "72eac405-89f9-423c-93f0-2c7919a54ec8",
+              "theText": "Une vieille balise est cachée dans les hautes herbes.\r\n\r\n{-} Un héros indemne peut interagir avec balise pour l'allumer.",
+              "buttonList": [
+                {
+                  "GUID": "062b6d8e-a8a5-4926-90fe-b04cfd4799b6",
+                  "theText": "{A} Allumer la balise"
+                }
+              ]
+            }
+          ],
+          "GUID": "dffe2be3-c998-479d-88da-4c0e6c5543ef",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        },
+        {
+          "tbText": "{-} Les pions Mission neutres représentent des balises. Un héros indemne peut interagir avec une balise pour l'allumer.\r\n{-} Pendant le round 6, au début de la phase de Statut, si tous les Héros sont sur les Champs (tuile 1B Lothal + ses terminaisons 18B Base) et qu'une balise a été allumée, les héros quittent les lieux. (Si la limite de Rounds est désactivée, les héros peuvent quitter les lieux pendant des Rounds ultérieurs).\r\n{-} Les Rebelles gagnent quand les héros quittent les lieux.",
+          "GUID": "3fcbc2af-f689-4078-9e2d-77346a297fc2",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "repositionText": "Bloquer l'accès aux Champs et aux balises.",
+          "GUID": "8fd5ec26-893e-4d07-8693-0c7a6b0a43cd",
+          "eventActionType": 17,
+          "eaName": "Change Reposition Instructions"
+        },
+        {
+          "shortText": "Aller sur les Champs et allumer une balise.",
+          "longText": null,
+          "GUID": "d692bd06-79b5-4093-816c-9b461bcd332a",
+          "eventActionType": 2,
+          "eaName": "Change Objective"
+        },
+        {
+          "theText": "{-} Quand un héros se replie, il est neutralisé à la place. Quand il est activé, il ne reçoit que 1 action, qu'il ne peut utiliser que pour se déplacer.\r\n{-} Les pions Mission neutres représentent des balises. Un héros indemne peut interagir avec une balise pour l'allumer. Pendant le round 6, au début de la phase de Statut, si tous les Héros sont sur les Champs (tuile 1B Lothal + ses terminaisons 18B Base) et qu'une balise a été allumée, les héros quittent les lieux. (Si la limite de Rounds est désactivée, les héros peuvent quitter les lieux pendant des Rounds ultérieurs).\r\n{-} Les Rebelles gagnent quand les héros quittent les lieux.",
+          "GUID": "3355f52c-c2fe-49b4-89e8-921293ea2274",
+          "eventActionType": 1,
+          "eaName": "Change Mission Info"
+        }
+      ]
+    },
+    {
+      "eventName": "Through the Grasses",
+      "GUID": "8e4e3e0c-636a-44bd-be5a-06cad04c466a",
+      "eventText": "Des petites mais féroces créatures se précipitent à travers les herbes dans une sifflement et avec leurs griffes toutes déployées.",
+      "eventActions": []
+    },
+    {
+      "eventName": "TtG 1",
+      "GUID": "6fbb5727-232f-4c90-9047-77337ae9ff72",
+      "eventText": "",
+      "eventActions": [
+        {
+          "enemyName": null,
+          "customText": "",
+          "modification": null,
+          "repositionInstructions": "",
+          "GUID": "a0fd6641-f4c6-4c06-9973-328e2525a9cc",
+          "eventActionType": 6,
+          "eaName": "Deploy: DG060/Loth-cat"
+        }
+      ]
+    },
+    {
+      "eventName": "TtG 2",
+      "GUID": "b115132b-4e81-4714-8a75-31524f9baadb",
+      "eventText": "",
+      "eventActions": [
+        {
+          "enemyName": null,
+          "customText": "",
+          "modification": null,
+          "repositionInstructions": "",
+          "GUID": "f0579950-6dab-401e-b0b9-a2f9e9adc14c",
+          "eventActionType": 6,
+          "eaName": "Deploy: DG060/Loth-cat"
+        }
+      ]
+    },
+    {
+      "eventName": "TtG 3",
+      "GUID": "0e11190b-c9fb-49af-9fd8-ebd5048611c1",
+      "eventText": "",
+      "eventActions": [
+        {
+          "enemyName": null,
+          "customText": "",
+          "modification": null,
+          "repositionInstructions": "",
+          "GUID": "5fa42b6a-3841-4359-a311-25bc7735bcf8",
+          "eventActionType": 6,
+          "eaName": "Deploy: DG060/Loth-cat"
+        }
+      ]
+    },
+    {
+      "eventName": "End of Mission - Rebels lose EoR 4",
+      "GUID": "aeed9077-9ae2-4d8d-8491-bd05c5418602",
+      "eventText": "Des explosions retentissent autour de vous en vous épargnant par miracle. Une silhouette en armure mandalorienne lance quelques grenades de plus depuis une navette, avant de vous lancer une corde.\r\n\r\n{-} Les Rebelles perdent la mission.",
+      "eventActions": [
+        {
+          "mainText": "Jouez-vous cette mission dans le cadre de la mini-campagne \"Tyrans de Lothal\" ?",
+          "buttonList": [
+            {
+              "GUID": "4f1c74f2-ebb7-4fbf-985d-cb259422cc82",
+              "theText": "Oui"
+            },
+            {
+              "GUID": "e207aa67-4ea8-4359-bfaa-7c78f4545c8c",
+              "theText": "Non"
+            }
+          ],
+          "GUID": "0ba34e01-d216-4e1d-a6e5-084b819b8751",
+          "eventActionType": 5,
+          "eaName": "Question Prompt"
+        }
+      ]
+    },
+    {
+      "eventName": "Light Flare 1",
+      "GUID": "e7c87a79-948c-43d2-84ce-bb6c436b710c",
+      "eventText": "La balise s'allume.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Flare 1",
+              "GUID": "978e86c8-1bf5-4969-a82e-1337fc5e5946",
+              "theText": "La balise est allumée. C'est le signal pour votre extraction.",
+              "buttonList": []
+            },
+            {
+              "entityName": "Flare 2",
+              "GUID": "ccc9ddb7-1597-4068-9695-77aa0ce2e2bb",
+              "theText": "Une vieille balise est cachée dans les hautes herbes.\r\n\r\n{-} Un héros indemne peut interagir avec balise pour l'allumer.",
+              "buttonList": [
+                {
+                  "GUID": "74e2f2b8-9df1-4407-8ee0-633530aa8e70",
+                  "theText": "{A} Allumer la balise"
+                }
+              ]
+            }
+          ],
+          "GUID": "8a546068-968d-47a3-99d3-f85608bb31c6",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "Light Flare 2",
+      "GUID": "6691f4dc-526d-4957-ab5c-6f41e1e1ce02",
+      "eventText": "La balise s'allume.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Flare 2",
+              "GUID": "f486d0f5-2018-4ae6-9844-faacdeb7b706",
+              "theText": "La balise est allumée. C'est le signal pour votre extraction.",
+              "buttonList": [
+                {
+                  "GUID": "ab2a6644-716d-4a90-8640-ddbf618d8f4e",
+                  "theText": "{A} Allumer la balise"
+                }
+              ]
+            },
+            {
+              "entityName": "Flare 1",
+              "GUID": "d08ac51e-6d8c-4000-80de-39775d884809",
+              "theText": "Une vieille balise est cachée dans les hautes herbes.\r\n\r\n{-} Un héros indemne peut interagir avec balise pour l'allumer.",
+              "buttonList": [
+                {
+                  "GUID": "ecb42195-2b64-4185-ab34-b9b83986af82",
+                  "theText": "{A} Allumer la balise"
+                }
+              ]
+            }
+          ],
+          "GUID": "b95e4db9-2699-4f40-ae98-9ad2634375d7",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "End of Mission - Rebels lose EoR 6",
+      "GUID": "98caa46e-9c66-420d-acf4-f1bb611f589c",
+      "eventText": "Des explosions retentissent autour de vous en vous épargnant par miracle. Une silhouette en armure mandalorienne lance quelques grenades de plus depuis une navette, avant de vous lancer une corde.\r\n\r\n{-} Les Rebelles perdent la mission.",
+      "eventActions": [
+        {
+          "mainText": "Jouez-vous cette mission dans le cadre de la mini-campagne \"Tyrans de Lothal\" ?",
+          "buttonList": [
+            {
+              "GUID": "fa2af160-9420-468e-b5e6-510bffd7ea14",
+              "theText": "Oui"
+            },
+            {
+              "GUID": "e477ac22-62ae-4bc1-8c88-c645aafe861f",
+              "theText": "Non"
+            }
+          ],
+          "GUID": "b1310a82-a6a2-4c3c-94b5-293dbc83de58",
+          "eventActionType": 5,
+          "eaName": "Question Prompt"
+        }
+      ]
+    },
+    {
+      "eventName": "Extraction",
+      "GUID": "5eaf63ee-16f4-4acf-b56d-4325802d6adf",
+      "eventText": "",
+      "eventActions": [
+        {
+          "mainText": "Tous les héros sont-ils sur les Champs (tuile 1B Lothal + ses terminaisons 18B Base) ?",
+          "buttonList": [
+            {
+              "GUID": "7e9a9323-8b98-4896-a980-9be34634924c",
+              "theText": "Oui"
+            },
+            {
+              "GUID": "2234c0c8-7daf-471b-bb00-62b978c6e5ae",
+              "theText": "Non"
+            }
+          ],
+          "GUID": "a860318a-30e3-41f3-997a-eb7fe75745ea",
+          "eventActionType": 5,
+          "eaName": "Question Prompt"
+        }
+      ]
+    },
+    {
+      "eventName": "Deadly Reinforcements",
+      "GUID": "49eecdc6-74bd-4c09-adfd-e737caa39cb8",
+      "eventText": "Alors que le mystérieux cargo s'approche pour vous extraire, vous apercevez une grande silhouette en armure noire qui vous observe à travers les hautes herbes.",
+      "eventActions": []
+    },
+    {
+      "eventName": "DR Red 1",
+      "GUID": "eb8a5e8e-54eb-4bcc-a716-c1d682db5059",
+      "eventText": "",
+      "eventActions": [
+        {
+          "enemyName": null,
+          "customText": "",
+          "modification": null,
+          "repositionInstructions": "",
+          "GUID": "0b44fbdb-01b6-4e0c-bb48-13a9c383c06c",
+          "eventActionType": 6,
+          "eaName": "Deploy: DG058/Death Trooper (Elite)"
+        }
+      ]
+    },
+    {
+      "eventName": "DR Red 2",
+      "GUID": "da3db78c-0222-41fe-83ad-d55227fa81a7",
+      "eventText": "",
+      "eventActions": [
+        {
+          "enemyName": null,
+          "customText": "",
+          "modification": null,
+          "repositionInstructions": "",
+          "GUID": "d1408fb0-631a-4fc1-973e-8b58cff8b388",
+          "eventActionType": 6,
+          "eaName": "Deploy: DG058/Death Trooper (Elite)"
+        }
+      ]
+    },
+    {
+      "eventName": "Flare lit",
+      "GUID": "9946a3cb-eaca-4308-a83d-2e59c6929d00",
+      "eventText": "C'est fait. La balise est allumée. Il ne vous reste plus qu'à tenir jusqu'à l'extraction.\r\n\r\n{-} Pendant le round 6, au début de la phase de Statut, si tous les Héros sont sur les Champs (tuile 1B Lothal + ses terminaisons 18B Base) et qu'une balise a été allumée, les héros quittent les lieux. (Si la limite de Rounds est désactivée, les héros peuvent quitter les lieux pendant des Rounds ultérieurs).",
+      "eventActions": [
+        {
+          "shortText": "Aller sur les Champs et tenir la position jusqu'à la fin du Round 6.",
+          "longText": null,
+          "GUID": "934de7db-bb04-4e4f-beeb-c87dfda44ac9",
+          "eventActionType": 2,
+          "eaName": "Change Objective"
+        },
+        {
+          "theText": "{-} Pendant le round 6, au début de la phase de Statut, si tous les Héros sont sur les Champs (tuile 1B Lothal + ses terminaisons 18B Base) et qu'une balise a été allumée, les héros quittent les lieux. (Si la limite de Rounds est désactivée, les héros peuvent quitter les lieux pendant des Rounds ultérieurs).\r\n{-} Les Rebelles gagnent quand les héros quittent les lieux.",
+          "GUID": "63eb5410-e28a-4074-aa84-a92a5948c1c6",
+          "eventActionType": 1,
+          "eaName": "Change Mission Info"
+        },
+        {
+          "repositionText": "Bloquer l'accès aux Champs.",
+          "GUID": "a738fc39-a402-4dfa-9bfc-e239876cda7f",
+          "eventActionType": 17,
+          "eaName": "Change Reposition Instructions"
+        }
+      ]
+    },
+    {
+      "eventName": "Round 6 has come",
+      "GUID": "7270b22d-c64b-4ce4-9466-de383dfaba6a",
+      "eventText": "",
+      "eventActions": []
+    }
+  ],
+  "mapEntities": [
+    {
+      "entityName": "Crate1",
+      "GUID": "dcf1e03e-e328-4f79-8427-e0a0bfc64f82",
+      "mainText": "Une vieille caisse de ravitaillement.",
+      "buttonList": [
+        {
+          "GUID": "e34c3439-87e3-4f2e-bf3e-74de40cebb38",
+          "theText": "{A} Ouvrir"
+        }
+      ]
+    },
+    {
+      "entityName": "Crate2",
+      "GUID": "461e69e0-7c26-42a1-ad2a-a5e71b4f7707",
+      "mainText": "Une vieille caisse de ravitaillement.",
+      "buttonList": [
+        {
+          "GUID": "35ce8ca5-b55d-4deb-adb6-6f3b402b1109",
+          "theText": "{A} Ouvrir"
+        }
+      ]
+    },
+    {
+      "entityName": "Entrance",
+      "GUID": "a343a128-3b10-48ff-878f-71c89176d776",
+      "mainText": "Déployer les héros ici.",
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Green 1",
+      "GUID": "c8062d94-a52f-4458-b2cf-3c7b515747e5",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Green 2",
+      "GUID": "5bdffef2-c7c7-4e16-ab66-dca82b0481fd",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Green 3",
+      "GUID": "64b4dbf2-4e39-4ce7-a5fe-94eed25c16d2",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Trooper 1",
+      "GUID": "81ead058-7663-414c-aed5-13a096cc71f9",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Trooper 2",
+      "GUID": "e4a239be-46e9-4900-8bde-7b22addd6076",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Trooper 3",
+      "GUID": "c8076ba2-7821-4a91-a270-17f63c43b8a1",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP DTrooper",
+      "GUID": "c0582188-b644-417a-84d6-ce48cec37d5d",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Officer",
+      "GUID": "f4ffe43c-5aa5-42c6-9e0e-49ae207f02e9",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "Shipment",
+      "GUID": "809ffe1c-f923-4dfb-a405-857eb3da9bc8",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "Extraction Point",
+      "GUID": "5623f69a-1069-4eaa-a0f9-149868929344",
+      "mainText": "Le vaisseau de votre contact vous attend ici.\r\n\r\n{-} Quand la cargaison entre sur cette case, cliquez sur \"Extraire la cargaison\".",
+      "buttonList": [
+        {
+          "GUID": "68abc7e8-d2e8-4208-a93a-0409a9dd21d5",
+          "theText": "Extraire la cargaison"
+        }
+      ]
+    },
+    {
+      "entityName": "DP Yellow 1",
+      "GUID": "97874263-64e3-4d2e-a6de-e70812d70ca2",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Yellow 2",
+      "GUID": "023eb255-f92b-4d04-b9e1-c3fd8594bb96",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Blue",
+      "GUID": "c6afcb04-34c4-4bdc-86a5-a579dd780c2c",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Red 1",
+      "GUID": "f0b362ab-ed1f-4b50-84fb-63b6c6389f8a",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Red 2",
+      "GUID": "567b4688-4d18-4d5f-ba35-b076b643c91b",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Extraction Point",
+      "GUID": "d1bc238a-30f2-4090-b981-7a772daee38b",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Loth 1",
+      "GUID": "a92e178c-0773-4db0-bef7-1fc6211f0544",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Loth 2",
+      "GUID": "43de767d-41cc-4c6a-87bc-4c6ae20bb83a",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Loth 3",
+      "GUID": "f042d66b-ebf2-4988-85e7-df9ac4b13939",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "Flare 1",
+      "GUID": "068d38fd-3572-4214-9dcf-3d9381f7e5dd",
+      "mainText": "Une vieille balise est cachée dans les hautes herbes.\r\n\r\n{-} Un héros indemne peut interagir avec balise pour l'allumer.",
+      "buttonList": [
+        {
+          "GUID": "7fdf9b90-7eb4-47e7-b4a0-2e9749034984",
+          "theText": "{A} Allumer la balise"
+        }
+      ]
+    },
+    {
+      "entityName": "Flare 2",
+      "GUID": "52404f4c-cce7-4d88-8450-00bec3c2c091",
+      "mainText": "Une vieille balise est cachée dans les hautes herbes.\r\n\r\n{-} Un héros indemne peut interagir avec balise pour l'allumer.",
+      "buttonList": [
+        {
+          "GUID": "8db9b2e0-0085-4d0f-8986-d499030d86f2",
+          "theText": "{A} Allumer la balise"
+        }
+      ]
+    }
+  ],
+  "initialGroups": [
+    {
+      "cardName": "Death Trooper",
+      "customInstructions": ""
+    },
+    {
+      "cardName": "Stormtrooper",
+      "customInstructions": ""
+    },
+    {
+      "cardName": "Imperial Officer",
+      "customInstructions": ""
+    }
+  ]
+}

--- a/ImperialCommander2/Assets/Resources/Languages/Fr/Missions/Lothal/LOTHAL2_FR.json
+++ b/ImperialCommander2/Assets/Resources/Languages/Fr/Missions/Lothal/LOTHAL2_FR.json
@@ -1,0 +1,726 @@
+{
+  "languageID": "French (FR)",
+  "missionProperties": {
+    "missionName": "Duel sur Dévaron",
+    "missionDescription": "Si vous jouez une mini-campagne, les héros doivent emmener un allié Spectre qu'ils n'ont pas déjà emmené lors d'une mission de cette mini-campagne. ==== Le père de Tress avait pour habitude de raconter les histoires les plus folles à propos de l'époque où il faisait de la contrebande d'épice dans toute la Bordure Extérieure. Elle se souvient de ses bravades... et de son obsession d'enregistrer et de mettre à l'abri toute hyperroute qu'il a pu emprunter. Bien qu'il ne soit plus de ce monde, ces enregistrements de navigation pourraient aider les contrebandiers Rebelles. Mais pour les obtenir, Tress devra retourner chez elle. Un endroit où ne l'attendent que des mauvais souvenirs.",
+    "missionInfo": "",
+    "campaignName": "Tyrans de Lothal",
+    "startingObjective": "",
+    "repositionOverride": "Bloquer l'accès à la porte.",
+    "additionalMissionInfo": "Si vous jouez une mini-campagne, les héros doivent emmener un allié Spectre qu'ils n'ont pas déjà emmené lors d'une mission de cette mini-campagne."
+  },
+  "events": [
+    {
+      "eventName": "Open Crate 1",
+      "GUID": "2dec36b9-ce77-4bf6-8c35-9489e6573609",
+      "eventText": "Vous fouillez la caisse et prenez ce qui vous semble utile.\r\n\r\nPiochez une carte Ravitaillement. Vous gagnez 1 médipack. Récupérez ce pion.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Crate1",
+              "GUID": "98355d5d-ed5b-490b-86f7-5bf1af68182a",
+              "theText": "Une vieille caisse de ravitaillement.",
+              "buttonList": [
+                {
+                  "GUID": "30fc70fe-f9c8-4726-8516-18cc975afe96",
+                  "theText": "{A} Ouvrir"
+                }
+              ]
+            }
+          ],
+          "GUID": "8eb6c4bb-fd64-4ae8-9b6d-a5ba3f737e6a",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "Open Crate 2",
+      "GUID": "74bbaee9-47db-48c2-b09c-7d0940adf6ab",
+      "eventText": "Vous fouillez la caisse et prenez ce qui vous semble utile.\r\n\r\nPiochez une carte Ravitaillement. Vous gagnez 1 médipack. Récupérez ce pion.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Crate2",
+              "GUID": "631f15b1-19e4-49d3-a270-b5168c8c27ee",
+              "theText": "Une vieille caisse de ravitaillement.",
+              "buttonList": []
+            }
+          ],
+          "GUID": "a6f06d59-b18c-465a-acc1-85db4a122e25",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "Open Crate 3",
+      "GUID": "4c60aea9-45d0-4dbe-9bea-27d51eba9079",
+      "eventText": "Vous fouillez la caisse et prenez ce qui vous semble utile.\r\n\r\nPiochez une carte Ravitaillement. Vous gagnez 1 médipack. Récupérez ce pion.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Crate3",
+              "GUID": "b61bdf53-aeeb-4014-9c3d-7f509ca2e00e",
+              "theText": "Une vieille caisse de ravitaillement.",
+              "buttonList": []
+            }
+          ],
+          "GUID": "50b5bf42-216f-45db-925e-d733f34fdd76",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "Mission Briefing",
+      "GUID": "edc56ae0-7e4f-4ecd-9176-26e69bfd835a",
+      "eventText": "La cabane Hacnua est envahie de mauvaises herbes et s'est effondrée, faute d'entretien. De nombreux signes indiquent que des formes de vie locales ont établi leur demeure dans ces ruines. Vous espérez que la puce de navigation du contrebandier a mieux survécu aux ravages du temps que le reste de l'habitation.\r\n\r\n{-} Déployez les héros sur la case bleue en surbrillance.",
+      "eventActions": [
+        {
+          "tbText": "La forêt est envahie par de longues plantes grimpantes allant jusqu'à la canopée.",
+          "GUID": "bb25a8db-2dd8-4722-b4d4-c61dc5dc3076",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Vine 1",
+              "GUID": "ec20f14c-234c-476d-8c18-7989e633d676",
+              "theText": null,
+              "buttonList": []
+            },
+            {
+              "entityName": "Vine 2",
+              "GUID": "a5264930-866d-4c2c-a2bb-453f474a3db7",
+              "theText": null,
+              "buttonList": []
+            },
+            {
+              "entityName": "Vine 3",
+              "GUID": "978a69f1-a2d6-4c5a-9de0-059848b94a74",
+              "theText": null,
+              "buttonList": []
+            },
+            {
+              "entityName": "Vine 4",
+              "GUID": "1c34a892-4486-4fd5-b71e-224a3edc6182",
+              "theText": null,
+              "buttonList": []
+            },
+            {
+              "entityName": "Vine 5",
+              "GUID": "a580cb16-255f-4885-a64c-9436b8613600",
+              "theText": null,
+              "buttonList": []
+            },
+            {
+              "entityName": "Vine 6",
+              "GUID": "d194fc8a-4d50-4cfb-925b-e054173feca2",
+              "theText": null,
+              "buttonList": []
+            },
+            {
+              "entityName": "Vine 7",
+              "GUID": "c57f3c16-be7d-427c-bfa6-22fea3929523",
+              "theText": null,
+              "buttonList": []
+            }
+          ],
+          "GUID": "f0bb5b32-4da5-4597-8733-87931a1a5f2a",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        },
+        {
+          "tbText": "{-} Les pions Mission neutres représentent des plantes grimpantes. Une CRÉATURE peut escalader une plante grimpante quand elle en reçoit l'instruction.\r\n{-} La mission évolue quand la porte de la cabane Hacnua s'ouvre.\r\n{-} Les Rebelles perdent quand tous les héros sont blessés.",
+          "GUID": "c29e29f7-d7cf-4a3a-9f43-9a26184adcc9",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Vine 1",
+              "GUID": "237beb64-2f5d-4296-a354-676215721cc6",
+              "theText": null,
+              "buttonList": []
+            },
+            {
+              "entityName": "Vine 2",
+              "GUID": "8785e613-35fb-4e64-844e-fe9f864ac9ad",
+              "theText": null,
+              "buttonList": []
+            },
+            {
+              "entityName": "Vine 3",
+              "GUID": "f634582d-ba73-413d-b86c-70e2c8331467",
+              "theText": null,
+              "buttonList": []
+            },
+            {
+              "entityName": "Vine 4",
+              "GUID": "4803ee3e-663c-4b13-8599-8a8032e0c5fd",
+              "theText": null,
+              "buttonList": []
+            },
+            {
+              "entityName": "Vine 5",
+              "GUID": "aa17f278-4bcb-4fd2-8de0-43c73f146d0a",
+              "theText": null,
+              "buttonList": []
+            },
+            {
+              "entityName": "Vine 6",
+              "GUID": "7f179edb-8a42-4573-9fde-ff19423163be",
+              "theText": null,
+              "buttonList": []
+            },
+            {
+              "entityName": "Vine 7",
+              "GUID": "b5eab4ef-8d84-4c01-82bb-26f82623a8a7",
+              "theText": null,
+              "buttonList": []
+            },
+            {
+              "entityName": "Entrance",
+              "GUID": "a5528289-4f97-49c9-8063-ecf8d437881e",
+              "theText": "Déployer les héros ici.",
+              "buttonList": []
+            }
+          ],
+          "GUID": "b2adcda9-2b1c-4644-9739-2b523f30e713",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        },
+        {
+          "shortText": "Entrer dans la cabane Hacnua.",
+          "longText": null,
+          "GUID": "b50c24ec-93a2-4b80-8a69-532e8d844db1",
+          "eventActionType": 2,
+          "eaName": "Change Objective"
+        },
+        {
+          "theText": "{-} Les pions Mission neutres représentent des plantes grimpantes. Une CRÉATURE peut escalader une plante grimpante quand elle en reçoit l'instruction.\r\n{-} La mission évolue quand la porte de la cabane Hacnua s'ouvre.\r\n{-} Les Rebelles perdent quand tous les héros sont blessés.",
+          "GUID": "14cca3ca-2041-4325-8788-956583cc21cd",
+          "eventActionType": 1,
+          "eaName": "Change Mission Info"
+        }
+      ]
+    },
+    {
+      "eventName": "End of Mission - Rebels win",
+      "GUID": "69b80fad-5e0e-46cd-a70e-defa45de4db6",
+      "eventText": "Meurtrie dans sa chair, la bête bat en retraite dans les arbres. Vous apercevez la puce de navigation dans la boue et la ramassez avant de vous diriger vers votre navette. Grâce à la contrebandière, vous savez que les plans de route que contient la puce sauveront de nombreux vaisseaux Rebelles.\r\n\r\n{-} Les Rebelles remportent la mission !",
+      "eventActions": [
+        {
+          "mainText": "Jouez-vous cette mission dans le cadre de la mini-campagne \"Tyrans de Lothal\" ?",
+          "buttonList": [
+            {
+              "GUID": "2848ceee-4ece-460b-b9fa-f62e74b2d54b",
+              "theText": "Oui"
+            },
+            {
+              "GUID": "e14386c6-67cd-444d-90c5-711eb1d91279",
+              "theText": "Non"
+            }
+          ],
+          "GUID": "fa160c96-ff1c-4306-ad5f-f40d51ef9331",
+          "eventActionType": 5,
+          "eaName": "Question Prompt"
+        }
+      ]
+    },
+    {
+      "eventName": "End of Mission - Rebels lose",
+      "GUID": "9e960fce-d271-468c-8d6c-233bc752aa52",
+      "eventText": "D'autres créatures aux dents aiguisées s'approchent furtivement depuis la forêt qui vous entoure. Vous avez subi de trop graves blessures. Vous savez que vous ne pouvez pas remporter ce combat. Les créatures chantent doucement pour célébrer leur triomphe tandis que vous regagnez votre navette. Les précieuses données de la puce de navigation sont perdues.\r\n\r\n{-} Les Rebelles perdent la mission.",
+      "eventActions": [
+        {
+          "mainText": "Jouez-vous cette mission dans le cadre de la mini-campagne \"Tyrans de Lothal\" ?",
+          "buttonList": [
+            {
+              "GUID": "3d9534b9-f7b9-416f-bf6e-47af4c8ef00d",
+              "theText": "Oui"
+            },
+            {
+              "GUID": "4e929a32-5d63-4d7e-bbf3-fef54a2960ac",
+              "theText": "Non"
+            }
+          ],
+          "GUID": "922d0b18-3b9c-4426-b8b1-9d79afd7d873",
+          "eventActionType": 5,
+          "eaName": "Question Prompt"
+        }
+      ]
+    },
+    {
+      "eventName": "Mini campaign Win",
+      "GUID": "1fb0c0b1-7388-42f6-9c4c-801de27f03a5",
+      "eventText": "Un croiseur Impérial est en mouvement pour intercepter votre vaisseau tandis que vous quittez Dévaron. Vos scanners repèrent une sortie de chasseurs TIE. Vous entrez une des routes du contrebandier dans votre ordinateur de navigation. Tandis que les TIE maintiennent un feu nourri contre vos boucliers, vous faites le saut dans l'hyperespace, où vous serez en sécurité.\r\n\r\nVous rencontrez le Ghost au point de rendez-vous. \"Enfin, ce n'est pas trop tôt\", commente Kanan. \"Voilà qui nous permettra de passer à travers toutes les patrouilles impériales du secteur. Certains de nos amis n'ont pas été réapprovisionnés depuis trop longtemps.\"\r\n\r\n{-} Chaque héros reçoit 3 XP.\r\n{-} Les héros reçoivent 300 crédits par héros.",
+      "eventActions": [
+        {
+          "mainText": "Veuillez sélectionner la bonne option :\r\n\r\n{-} Campagne étendue 1 : vous jouez la mini-campagne étendue avec l'extension de figurines \"Ezra Bridger et Kanan Jarrus\".\r\n{-} Campagne étendue 2 : vous jouez la mini-campagne étendue avec l'extension de figurines \"Sabine Wren et Zeb Orrelios\".\r\n{-} Campagne étendue 3 : vous jouez la mini-campagne étendue avec ces deux extensions de figurines.\r\n{-} Mini-campagne : vous jouez la mini-campagne \"Tyrans de Lothal\" sans aucune de ces deux extensions de figurine.",
+          "buttonList": [
+            {
+              "GUID": "f38bcda5-5002-47c9-9be4-2c29cceb86c1",
+              "theText": "Campagne étendue 1"
+            },
+            {
+              "GUID": "d9a67003-b4c0-4ed0-a3b5-9f93dab2d44d",
+              "theText": "Campagne étendue 2"
+            },
+            {
+              "GUID": "7a0a12a1-6ad3-4436-9e24-7ccac7a4b774",
+              "theText": "Campagne étendue 3"
+            },
+            {
+              "GUID": "ae8e16ba-e969-48bc-b225-e22168009165",
+              "theText": "Mini-campagne"
+            }
+          ],
+          "GUID": "d93f8f65-094a-440f-bd2c-2849d9099137",
+          "eventActionType": 5,
+          "eaName": "Question Prompt"
+        }
+      ]
+    },
+    {
+      "eventName": "Mini campaign Defeat",
+      "GUID": "ee9e6f21-9b9f-47ca-b982-44b59453a837",
+      "eventText": "Mal en point et épuisés, vous vous effondrez sur votre couchette sans rien avoir rapporté de votre excursion à Dévaron qu'une certitude : la galaxie est un endroit mortellement dangereux.\r\n\r\nVous avez un rendez-vous avec le Ghost quelques jours plus tard. Hera vous donne l'impression de ne pas avoir dormi depuis la dernière fois que vous l'avez vue. \"L'Empire intensifie ses patrouilles. Nous perdons du terrain.\"\r\n\r\n{-} Chaque héros reçoit 3 XP.\r\n{-} Les héros reçoivent 300 crédits par héros.",
+      "eventActions": [
+        {
+          "mainText": "Veuillez sélectionner la bonne option :\r\n\r\n{-} Campagne étendue 1 : vous jouez la mini-campagne étendue avec l'extension de figurines \"Ezra Bridger et Kanan Jarrus\".\r\n{-} Campagne étendue 2 : vous jouez la mini-campagne étendue avec l'extension de figurines \"Sabine Wren et Zeb Orrelios\".\r\n{-} Campagne étendue 3 : vous jouez la mini-campagne étendue avec ces deux extensions de figurines.\r\n{-} Mini-campagne : vous jouez la mini-campagne \"Tyrans de Lothal\" sans aucune de ces deux extensions de figurine.",
+          "buttonList": [
+            {
+              "GUID": "478603a5-77a4-4a5d-ab8d-bf0bb218839b",
+              "theText": "Campagne étendue 1"
+            },
+            {
+              "GUID": "49095fe8-844c-4bd5-9838-558b621f7bfb",
+              "theText": "Campagne étendue 2"
+            },
+            {
+              "GUID": "9047e13c-0885-4dce-a423-c3d1d7e8e89e",
+              "theText": "Campagne étendue 3"
+            },
+            {
+              "GUID": "ee150c3e-a066-486c-83f1-c3098775fc52",
+              "theText": "Mini-campagne"
+            }
+          ],
+          "GUID": "c47a75a7-d9d7-4f27-ab49-39ee814934b8",
+          "eventActionType": 5,
+          "eaName": "Question Prompt"
+        }
+      ]
+    },
+    {
+      "eventName": "No campaign",
+      "GUID": "8fe1b24a-487b-46a0-9e81-94329508e0dc",
+      "eventText": "{-} Chaque héros reçoit 1 XP.\r\n{-} Les héros reçoivent 100 crédits par héros.",
+      "eventActions": []
+    },
+    {
+      "eventName": "Extended campaign 1",
+      "GUID": "2f95d44b-fe49-4580-aed5-8b4db04f67d8",
+      "eventText": "\"Nous faisons profil bas\", vous informe Hera. Ce dont nous avons le plus besoin à présent, c'est de quelque chose pour distraire Thrawn.\"\r\n\r\nVotre contact sur Lothal, le droïde N-4M, est heureux d'entendre de vos nouvelles. Enfin, aussi heureux que puisse l'être un droïde analyste. \"Vous avez mis la garnison locale dans un léger embarras. Ils se préparent à faire face à une possible attaque de plus grande ampleur de la part des Rebelles.\"\r\n\r\nN-4M met de côté son holoprojecteur pour se concentrer sur la surface de Lothal. \"L'Empire exploite ses travailleurs forcés encore plus durement que d'habitude. Un officier en particulier, le Colonel Xarok, jouit d'une réputation de plus en plus mauvaise. Il semble que ses pratiques soient particulièrement... agressives.\"\r\n\r\n{-} La prochaine mission active est \"Abus de l'exécutif\" (extension de figurines allié Ezra et Kanan).",
+      "eventActions": []
+    },
+    {
+      "eventName": "Extended campaign 2",
+      "GUID": "fbdc139d-95c5-421b-9b4a-ace4b3010a6b",
+      "eventText": "\"Nous faisons profil bas\", vous informe Hera. Ce dont nous avons le plus besoin à présent, c'est de quelque chose pour distraire Thrawn.\"\r\n\r\nVotre contact sur Lothal, le droïde N-4M, est heureux d'entendre de vos nouvelles. Enfin, aussi heureux que puisse l'être un droïde analyste. \"Vous avez mis la garnison locale dans un léger embarras. Ils se préparent à faire face à une possible attaque de plus grande ampleur de la part des Rebelles.\"\r\n\r\nN-4M sort un schéma des routes de ravitaillement Impériales menant vers Lothal. \"Plusieurs travailleurs wookies se sont rebellés récemment dans un camp directement lié aux activités de Thrawn. Leur soulèvement a échoué et l'Empire menace à présent leurs familles de représailles. Peut-être pourriez-vous intervenir en faveur des Wookies ?\"\r\n\r\n{-} La prochaine mission active est \"Facteur d'intimidation\" (extension de figurines allié Sabine et Zeb).",
+      "eventActions": []
+    },
+    {
+      "eventName": "Extended campaign 3",
+      "GUID": "3b320c43-2936-47f5-8dab-d5677138c38d",
+      "eventText": "\"Nous faisons profil bas\", vous informe Hera. Ce dont nous avons le plus besoin à présent, c'est de quelque chose pour distraire Thrawn.\"\r\n\r\nVotre contact sur Lothal, le droïde N-4M, est heureux d'entendre de vos nouvelles. Enfin, aussi heureux que puisse l'être un droïde analyste. \"Vous avez mis la garnison locale dans un léger embarras. Ils se préparent à faire face à une possible attaque de plus grande ampleur de la part des Rebelles.\"\r\n\r\nN-4M met de côté son holoprojecteur pour se concentrer sur la surface de Lothal. \"L'Empire exploite ses travailleurs forcés encore plus durement que d'habitude. Un officier en particulier, le Colonel Xarok, jouit d'une réputation de plus en plus mauvaise. Il semble que ses pratiques soient particulièrement... agressives.\"\r\n\r\nN-4M sort un schéma des routes de ravitaillement Impériales menant vers Lothal. \"Plusieurs travailleurs wookies se sont rebellés récemment dans un camp directement lié aux activités de Thrawn. Leur soulèvement a échoué et l'Empire menace à présent leurs familles de représailles. Peut-être pourriez-vous intervenir en faveur des Wookies ?\"\r\n\r\n{-} Les héros choisissent collectivement s'ils souhaitent attaquer le Colonel Xarok ou s'ils préfèrent aider les Wookies.\r\n{-} Si les héros choisissent d'attaquer le colonel Xarok, la prochaine mission active est \"Abus de l'exécutif\" (extension de figurines allié Ezra et Kanan).\r\n{-} Si les héros choisissent d'aider les Wookies, la prochaine mission active est \"Facteur d'intimidation\" (extension de figurines allié Sabine et Zeb).",
+      "eventActions": []
+    },
+    {
+      "eventName": "Regular mini campaign",
+      "GUID": "5912594d-6f76-449a-8572-5004d336bdd9",
+      "eventText": "À bord du Ghost, vous trouvez Hera et Sabine en train d'étudier les restes d'un droïde infiltrateur E-XD. Nous nous sommes aperçues que plusieurs de ces choses tentaient de nous suivre dernièrement\", commenta Hera. \"Et Thrawn n'a pas encore abandonné. Nous devons jouer à armes égales.\"\r\n\r\n\"Alors, donnons-lui d'autres sujets d'inquiétudes\", suggéra Sabine. \"Même si cela ne mobilise que quelques stormtroopers. Nous ne sommes pas restés suffisamment longtemps sur Géonosis pour que je puisse m'en assurer, mais je pense que nous pourrions être capables de remettre en marche une partie de ces vieux droïdes de combat.\"\r\n\r\n\"Ou\", intervint Hera, \"nous pouvons essayer d'aider les rebelles Twi'lek sur Ryloth. L'Empire a intercepté leurs équipements depuis un moment maintenant. Si nous pouvons les aider à revenir dans la lutte, Thrawn aura une nouvelle épine dans le pied.\"\r\n\r\n{-} Les héros choisissent collectivement s'ils souhaitent inspecter l'usine de droïdes ou porter assistance aux rebelles Twi'lek.\r\n{-} Si les héros choisissent d'inspecter l'usine de droïdes, la prochaine mission active est \"État de siège sur Géonosis\".\r\n{-} Si les héros choisissent de porter assistance aux rebelles Twi'lek, la prochaine mission active est \"Course de vitesse sur Ryloth\".",
+      "eventActions": []
+    },
+    {
+      "eventName": "The Lodge",
+      "GUID": "ee18dfff-083a-4822-ac45-538eebdbadc8",
+      "eventText": "La porte de la cabane s'ouvre et révèle un intérieur délabré.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Door 1",
+              "GUID": "5f146faf-b445-4c5a-84b6-b2688f9a4ec8",
+              "theText": "L'ancienne porte de la cabane Hacnua semble usée par les intempéries, mais intacte.",
+              "buttonList": []
+            }
+          ],
+          "GUID": "b6b9c1eb-0611-4c89-87a1-604c1f3be60d",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        },
+        {
+          "tbText": "Une autre plante grimpante monte à travers le plafond brisé.",
+          "GUID": "b7a80ce4-7a69-410f-bc9c-c51c53042971",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Vine 8",
+              "GUID": "06eb79a1-a5f3-4416-81fd-cc4b1a9489d9",
+              "theText": null,
+              "buttonList": []
+            }
+          ],
+          "GUID": "3676625b-a8a5-4bd8-bd0b-8898da70ecd9",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        },
+        {
+          "tbText": "Un loth-cat ronge les restes d'une puce de navigation. Il penche sa tête sur le côté et coince la puce entre ses mâchoires.",
+          "GUID": "871ca9fc-1947-4cdb-bea9-0e407f781152",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Navchip",
+              "GUID": "3dbb7dcc-b2c5-4469-908d-999d6a18344c",
+              "theText": null,
+              "buttonList": []
+            }
+          ],
+          "GUID": "5e29c3bf-aa9f-412f-a324-90813ba3e2f9",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        },
+        {
+          "enemyName": null,
+          "customText": "",
+          "modification": null,
+          "repositionInstructions": "",
+          "GUID": "fefc0fd5-c142-41ce-a4aa-c9e6cb9654a0",
+          "eventActionType": 6,
+          "eaName": "Deploy: DG061/Loth-cat (Elite)"
+        },
+        {
+          "tbText": "{-} Le pion Mission Rebelle bleu représente la puce de navigation. \r\n{-} Le premier <color=\"red\">Loth-cat</color> déployé bénéficie d'une interruption pour récupérer la puce de navigation et gagne 1 {g}.\r\n{-} La mission évolue quand le <color=\"red\">Loth-cat</color> qui transporte la puce de navigation est vaincu. Quand cela se produit, cliquez sur l'Entrée et sélectionnez \"Loth-cat vaincu\".",
+          "GUID": "bccb10f0-08e6-488f-aecf-83e7fc0d18ba",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Entrance",
+              "GUID": "95341e12-ee8f-4b48-b98f-a2b791766914",
+              "theText": "Quand le <color=\"red\">Loth-cat</color> qui transporte la puce de navigation est vaincu, cliquez sur \"Loth-cat vaincu\".",
+              "buttonList": [
+                {
+                  "GUID": "2466a800-c99b-4b9a-bd92-5455403e8c09",
+                  "theText": "Loth-cat vaincu"
+                }
+              ]
+            },
+            {
+              "entityName": "Navchip",
+              "GUID": "7570dcf7-ee1f-422a-a4fd-92825417af20",
+              "theText": null,
+              "buttonList": []
+            },
+            {
+              "entityName": "Vine 8",
+              "GUID": "c3cf6d75-6ba5-4319-b6a4-bbb980fae089",
+              "theText": null,
+              "buttonList": []
+            }
+          ],
+          "GUID": "6bbeb610-61fe-4d72-99c2-b693d948cd17",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        },
+        {
+          "repositionText": "Bloquer l'accès au <color=\"red\">Loth-cat</color> qui transporte la puce de navigation.",
+          "GUID": "f61cfc87-bdff-4474-aaef-31670c1a7361",
+          "eventActionType": 17,
+          "eaName": "Change Reposition Instructions"
+        },
+        {
+          "shortText": "Vaincre le <color=\"red\">Loth-cat</color> qui transporte la puce de navigation.",
+          "longText": null,
+          "GUID": "5ae2eded-aa51-4ca3-8cf2-14a9d7413867",
+          "eventActionType": 2,
+          "eaName": "Change Objective"
+        },
+        {
+          "theText": "{-} Les pions Mission neutres représentent des plantes grimpantes. Une CRÉATURE peut escalader une plante grimpante quand elle en reçoit l'instruction.\r\n{-} La mission évolue quand le <color=\"red\">Loth-cat</color> qui transporte la puce de navigation est vaincu. Quand cela se produit, cliquez sur l'Entrée et sélectionnez \"Loth-cat vaincu\".\r\n{-} Les Rebelles perdent quand tous les héros sont blessés.",
+          "GUID": "597da244-7793-4e23-945b-a9424a653f96",
+          "eventActionType": 1,
+          "eaName": "Change Mission Info"
+        }
+      ]
+    },
+    {
+      "eventName": "Loth-cat activation",
+      "GUID": "513ede0e-039d-4d01-8d7a-793e7c257626",
+      "eventText": "Le <color=\"red\">Loth-cat</color> qui transporte la puce de navigation résout les instructions suivantes :\r\n\r\n{-} NEUF VIES: Les attaques de cette figurine gagnent Éliminer 2 {H}.\r\n\r\n{Q} BOND : Placer cette figurine dans une case vide à 6 cases ou moins et adjacente à {rebel}. Puis Attaque {rebel}.\r\n{A} ATTRAPE-MOI SI TU PEUX : Déplacement 3 pour escalader une plante grimpante. Défausser cette plante grimpante et placer cette figurine sur la case de la plante grimpante la plus éloignée des Rebelles. Puis, défausser cette plante grimpante.\r\n{A} Déplacement 6 pour s'éloigner des Rebelles.\r\n{A} Déplacement 4 pour s'éloigner des Rebelles.\r\n{-} PRISE FRAÎCHE : Cette figurine gagne 1 {g} et 1 {h}.\r\n\r\n{-} FRAYEUR: Après l'activation de cette figurine, le Rebelle le plus proche effectue un test {J}. S'il échoue, cette figurine se déplace de 6 pour s'éloigner des Rebelles et gagne 1 {f}.\r\n\r\nEnsuite, l'autre <color=\"red\">Loth-cat</color> (s'il est encore en vie) s'active normalement.",
+      "eventActions": []
+    },
+    {
+      "eventName": "Reunion",
+      "GUID": "b4ecd441-c8bf-4fe7-99c7-a0fe7b2dfb9f",
+      "eventText": "La créature se met à hurler. Dans un bruissement de feuilles, un énorme nexu couvert de cicatrices se laisse tomber des arbres. Le loth-cat apeuré trouve refuge sur le dos de la créature en emportant la puce de navigation entre ses dents alors que le nexu découvre les siennes en guise d'avertissement.",
+      "eventActions": [
+        {
+          "enemyName": null,
+          "customText": "{-} VIEILLE RANCUNE : Cette figurine gagne 1 {h}.\r\n{A}{A} Si cette figurine a subi au moins 6 {H}, éliminer 4 {H}. Puis Déplacement de 10 pour s'éloigner des Rebelles.\r\n{Q} BOND : Placer cette figurine dans une case vide à 6 cases ou moins et adjacente à au moins 2 Rebelles. Puis Attaque {rebel}.\r\n{Q} BOND : Placer cette figurine dans une case vide à 6 cases ou moins et adjacente à {rebel}. Puis Attaque {rebel}.\r\n{A} ATTRAPE-MOI SI TU PEUX : Déplacement 3 pour escalader une plante grimpante. Défausser cette plante grimpante et placer cette figurine sur la case de la plante grimpante la plus éloignée des Rebelles. Puis, défausser cette plante grimpante.\r\n{A} Déplacement 4 pour s'éloigner des Rebelles.\r\n{A} Déplacement 10 pour s'éloigner des Rebelles.",
+          "modification": "+*2* Santé",
+          "repositionInstructions": "",
+          "GUID": "4ed19448-de6e-4c76-bbfe-ddead3bc66fe",
+          "eventActionType": 6,
+          "eaName": "Deploy: DG018/Nexu (Elite)"
+        },
+        {
+          "tbText": "{-} Déployez le <color=\"red\">Nexu</color> sur la case qu'occupait le <color=\"red\">Loth-cat</color> vaincu.\r\n{-} Appliquez au <color=\"red\">Nexu</color> une Santé additionnelle égale au double du niveau de menace.\r\n{-} Le <color=\"red\">Nexu</color> perd \"Intelligence Limitée\".\r\n{-} Le <color=\"red\">Nexu</color> bénéficie d'une interruption pour récupérer la puce de navigation.\r\n{-} Les Rebelles gagnent quand le <color=\"red\">Nexu</color> est vaincu.",
+          "GUID": "b38fc6ac-7559-465e-8479-9222c29cd78e",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "tbText": "Alertés par le vacarme, d'autres ennemis se précipitent.",
+          "GUID": "19cdecbd-4a5d-4197-b4ea-e806461cfb93",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "repositionText": "Bloquer l'accès au <color=\"red\">Nexu</color>.",
+          "GUID": "0d712244-63a9-4949-86c8-5c85dd3923d3",
+          "eventActionType": 17,
+          "eaName": "Change Reposition Instructions"
+        },
+        {
+          "shortText": "Vaincre le <color=\"red\">Nexu</color>.",
+          "longText": "",
+          "GUID": "2f26c715-3d89-47e8-9b1d-ff196fe4e4fd",
+          "eventActionType": 2,
+          "eaName": "Change Objective"
+        },
+        {
+          "theText": "{-} Les pions Mission neutres représentent des plantes grimpantes. Une CRÉATURE peut escalader une plante grimpante quand elle en reçoit l'instruction.\r\n{-} Les Rebelles gagnent quand le <color=\"red\">Nexu</color> est vaincu.\r\n{-} Les Rebelles perdent quand tous les héros sont blessés.",
+          "GUID": "79495923-f11f-4f79-be85-5c58771e6293",
+          "eventActionType": 1,
+          "eaName": "Change Mission Info"
+        }
+      ]
+    },
+    {
+      "eventName": "Tress Yes",
+      "GUID": "77df2b50-85d6-423a-a07a-cc73c6a76fd2",
+      "eventText": "Un frisson parcourt l'épaule de Tress. Un souvenir douloureux refait surface lorsqu'elle reconnaît le monstre. Elle lève un poing ganté de duracier. \"Prêt pour la revanche ?\"",
+      "eventActions": []
+    },
+    {
+      "eventName": "Tress present",
+      "GUID": "f601b513-baf1-49c0-af84-ca7eb67e54d7",
+      "eventText": "",
+      "eventActions": []
+    },
+    {
+      "eventName": "Mission Ends Win Tress Yes",
+      "GUID": "3fa810bd-03be-4388-97ed-038fda088607",
+      "eventText": "Tress Hacnua reçoit la carte Récompense \"Plénitude\".",
+      "eventActions": []
+    },
+    {
+      "eventName": "Mission Ends Win Tress No",
+      "GUID": "db0e4298-cfe5-4bb8-8062-3ee0194026ce",
+      "eventText": "Les héros reçoivent 150 crédits par héros.",
+      "eventActions": []
+    },
+    {
+      "eventName": "Mission Ends Defeat",
+      "GUID": "3a675688-3793-4e9d-a3fb-5584bdaa1ab4",
+      "eventText": "",
+      "eventActions": []
+    }
+  ],
+  "mapEntities": [
+    {
+      "entityName": "Crate1",
+      "GUID": "dcf1e03e-e328-4f79-8427-e0a0bfc64f82",
+      "mainText": "Une vieille caisse de ravitaillement.",
+      "buttonList": [
+        {
+          "GUID": "4d884980-e9d4-4355-9a42-af7b9d59a573",
+          "theText": "{A} Ouvrir"
+        }
+      ]
+    },
+    {
+      "entityName": "Crate2",
+      "GUID": "461e69e0-7c26-42a1-ad2a-a5e71b4f7707",
+      "mainText": "Une vieille caisse de ravitaillement.",
+      "buttonList": [
+        {
+          "GUID": "3a90dc78-8835-417f-b6cc-e2564e2e1310",
+          "theText": "{A} Ouvrir"
+        }
+      ]
+    },
+    {
+      "entityName": "Crate3",
+      "GUID": "1e60bee2-7e72-4f71-8c0e-45b5a2d0baf8",
+      "mainText": "Une vieille caisse de ravitaillement.",
+      "buttonList": [
+        {
+          "GUID": "b68f1be1-ad16-486b-8912-f6ae839665d8",
+          "theText": "{A} Ouvrir"
+        }
+      ]
+    },
+    {
+      "entityName": "Entrance",
+      "GUID": "a343a128-3b10-48ff-878f-71c89176d776",
+      "mainText": "Déployer les héros ici.",
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Green 1",
+      "GUID": "c8062d94-a52f-4458-b2cf-3c7b515747e5",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Green 2",
+      "GUID": "5bdffef2-c7c7-4e16-ab66-dca82b0481fd",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Green 3",
+      "GUID": "64b4dbf2-4e39-4ce7-a5fe-94eed25c16d2",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Probe Droid",
+      "GUID": "81ead058-7663-414c-aed5-13a096cc71f9",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "Door 1",
+      "GUID": "97717a60-2e42-467d-a90b-e67162d5b1aa",
+      "mainText": "L'ancienne porte de la cabane Hacnua semble usée par les intempéries, mais intacte.",
+      "buttonList": [
+        {
+          "GUID": "c50eab15-28cf-436e-9369-36bb63a804c1",
+          "theText": "{A} Ouvrir"
+        }
+      ]
+    },
+    {
+      "entityName": "DP Loth 1",
+      "GUID": "c69d36df-6b10-4832-8d65-79909c85303c",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Loth 2",
+      "GUID": "20a61fb1-028d-4f81-9636-b5cfedf6aec6",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Nexu",
+      "GUID": "6b9c99bd-76dc-41b3-8550-fe6b3ff179c4",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Yellow",
+      "GUID": "c1190b98-7117-438f-9407-221347070ad8",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "Navchip",
+      "GUID": "874c2793-e70c-42f3-8a98-11898f3b51f5",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "Vine 1",
+      "GUID": "32c578c2-d79a-4f1a-bedd-f5bb883008aa",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "Vine 2",
+      "GUID": "75080cb7-c3ca-4fd1-888d-d88fd564c5a1",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "Vine 3",
+      "GUID": "b04f277c-6d94-48a9-b3e8-8f99c523276f",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "Vine 4",
+      "GUID": "57c9f3b2-e64a-4579-a35b-069e48aabb8d",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "Vine 5",
+      "GUID": "6e02440f-cb50-41fb-a4b8-03e933bc7994",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "Vine 6",
+      "GUID": "e7bbc8e1-6979-485f-9a85-fe076ee2dfaf",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "Vine 7",
+      "GUID": "648f70a1-999f-4508-9b40-6ac0466106b4",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "Vine 8",
+      "GUID": "646b9209-0e23-4580-8350-1f5627cad8f0",
+      "mainText": null,
+      "buttonList": []
+    }
+  ],
+  "initialGroups": [
+    {
+      "cardName": "Probe Droid",
+      "customInstructions": ""
+    },
+    {
+      "cardName": "Nexu",
+      "customInstructions": ""
+    },
+    {
+      "cardName": "Loth-cat",
+      "customInstructions": ""
+    }
+  ]
+}

--- a/ImperialCommander2/Assets/Resources/Languages/Fr/Missions/Lothal/LOTHAL3_FR.json
+++ b/ImperialCommander2/Assets/Resources/Languages/Fr/Missions/Lothal/LOTHAL3_FR.json
@@ -1,0 +1,863 @@
+{
+  "languageID": "French (FR)",
+  "missionProperties": {
+    "missionName": "Course de vitesse sur Ryloth",
+    "missionDescription": "Si vous jouez une mini-campagne, les héros doivent emmener un allié Spectre qu'ils n'ont pas déjà emmené lors d'une mission de cette mini-campagne. ==== Un récent raid du BSI a intercepté des équipements d'une importance vitale pour la résistance de Ryloth, ainsi que des données cryptées rapportant en détail leurs opérations sur toute la planète. Héra Syndulla a dépêché un de ses équipiers pour vous aider à récupérer le matériel et les informations avant que l'Empire ne s'en serve contre les Rebelles Twi'lek.",
+    "missionInfo": "",
+    "campaignName": "Tyrans de Lothal",
+    "startingObjective": "",
+    "repositionOverride": "{-} Les figurines ne se trouvant pas sur la section la plus au nord : Se déplacer vers la section la plus au nord. Autant que possible, éviter les pions Mission neutres.\n{-} Les figurines sur la section la plus au nord : Bloquer le passage aux figurines Rebelles. Autant que possible, éviter les pions Mission neutres.",
+    "additionalMissionInfo": "Si vous jouez une mini-campagne, les héros doivent emmener un allié Spectre qu'ils n'ont pas déjà emmené lors d'une mission de cette mini-campagne."
+  },
+  "events": [
+    {
+      "eventName": "Open Crate 1",
+      "GUID": "2dec36b9-ce77-4bf6-8c35-9489e6573609",
+      "eventText": "Vous fouillez la caisse et prenez ce qui vous semble utile.\r\n\r\nPiochez une carte Ravitaillement. Vous gagnez 1 médipack. Récupérez ce pion.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Crate1",
+              "GUID": "31b107b8-1479-4562-93cf-7bae0c95539f",
+              "theText": "Une vieille caisse de ravitaillement.",
+              "buttonList": [
+                {
+                  "GUID": "6a09ef61-9984-471e-9313-b436e973b67d",
+                  "theText": "{A} Ouvrir"
+                }
+              ]
+            }
+          ],
+          "GUID": "8eb6c4bb-fd64-4ae8-9b6d-a5ba3f737e6a",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "Open Crate 2",
+      "GUID": "74bbaee9-47db-48c2-b09c-7d0940adf6ab",
+      "eventText": "Vous fouillez la caisse et prenez ce qui vous semble utile.\r\n\r\nPiochez une carte Ravitaillement. Vous gagnez 1 médipack. Récupérez ce pion.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Crate2",
+              "GUID": "731ff638-7475-4c96-a039-030482ee2327",
+              "theText": "Une vieille caisse de ravitaillement.",
+              "buttonList": []
+            }
+          ],
+          "GUID": "a6f06d59-b18c-465a-acc1-85db4a122e25",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "Open Crate 3",
+      "GUID": "4c60aea9-45d0-4dbe-9bea-27d51eba9079",
+      "eventText": "Vous fouillez la caisse et prenez ce qui vous semble utile.\r\n\r\nPiochez une carte Ravitaillement. Vous gagnez 1 médipack. Récupérez ce pion.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Crate3",
+              "GUID": "952baab0-f93b-46a5-9c43-e6c4f72c2ca1",
+              "theText": "Une vieille caisse de ravitaillement.",
+              "buttonList": []
+            }
+          ],
+          "GUID": "50b5bf42-216f-45db-925e-d733f34fdd76",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "Mission Briefing",
+      "GUID": "edc56ae0-7e4f-4ecd-9176-26e69bfd835a",
+      "eventText": "Vous approchez de l'endroit où vous avez localisé la navette Impériale qui détient la marchandise volée. Au loin, vous apercevez les flammes de ses moteurs. Les blurrgs que vous avez empruntés attendent de courir avec impatience, mais il leur faudra être plus rapides que les motojets de l'Empire.\r\n\r\n{-} Déployez les héros sur la case bleue en surbrillance.\r\n{-} Les murs qui touchent les murs de tuiles adjacentes ne bloquent pas la ligne de vue, les déplacements et l'adjacence, et n'empêche pas de compter les cases.\r\n{-} Tant qu'elles sont sur des cases d'extérieur :\r\n— Les figurines et les capacités ignorent tous les terrains.\r\n— Au début de chaque activation d'une figurine Rebelle, cette dernière gagne 3 points de déplacement.\r\n— Les figurines Impériales ne peuvent volontairement se déplacer que vers le Nord, le Nord-Ouest, ou le Nord-Est.",
+      "eventActions": [
+        {
+          "newInstructions": "{-} MOTOJET : Tant qu'elles sont sur des cases d'extérieur, ajouter +1 en Vitesse à toutes les instructions de Déplacement. Cette figurine ne peut volontairement se déplacer que vers le Nord, le Nord-Ouest, ou le Nord-Est et ignore tous les terrains.",
+          "GUID": "2a332c96-451b-4e52-84bf-0865bed15aca",
+          "eventActionType": 11,
+          "eaName": "Change Group Instructions"
+        },
+        {
+          "tbText": "Des rochers se sont détachés des parois du canyon et bloquent le passage. Les blurrgs peuvent facilement les contourner, mais ils représentent un réel danger pour les conducteurs de motojets.",
+          "GUID": "86d76723-5bf7-470b-9762-eb8aa22e94f0",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Rocks 1",
+              "GUID": "2b6dc4dd-9d5a-4445-8a88-df85c43b1c17",
+              "theText": "Des rochers sont tombés dans le canyon à cet endroit, bloquant le passage.\r\n\r\n{-} Quand une figurine Impériale entre dans une case qui contient un pion Mission neutre, elle subit 2 {H}.",
+              "buttonList": []
+            },
+            {
+              "entityName": "Rocks 2",
+              "GUID": "f1224c4c-1eba-4d67-a5ce-cf2e8d40cec1",
+              "theText": "Des rochers sont tombés dans le canyon à cet endroit, bloquant le passage.\r\n\r\n{-} Quand une figurine Impériale entre dans une case qui contient un pion Mission neutre, elle subit 2 {H}.",
+              "buttonList": []
+            }
+          ],
+          "GUID": "19e5f167-d658-440c-8f77-3df5874519da",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        },
+        {
+          "tbText": "{-} Quand une figurine Impériale entre dans une case qui contient un pion Mission neutre, elle subit 2 {H}.",
+          "GUID": "80ddc10c-7443-471c-a64a-3a3f1bc709eb",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "tbText": "Vous enfourchez vos blurrgs. Vous devez faire vite si vous voulez atteindre la navette à temps.\r\n\r\n{-} Au début de chaque phase de Statut, la section la plus au sud est retirée et chaque figurine qui était encore dessus est poussée vers la section suivante au nord, tout en subissant {H} et/ou {B} comme indiqué par l'application. La section suivante est ensuite ajoutée. Utilisez des Culs-de-sac (tuiles 18B Base, 12B Lothal) si nécessaire.\r\n{-} La mission évolue quand les Rebelles atteignent la navette.\r\n{-} Les Rebelles perdent quand tous les héros sont blessés.",
+          "GUID": "cd01c3ee-796a-4324-b74b-aba263509ae0",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "shortText": "Atteindre la navette.",
+          "longText": "",
+          "GUID": "264612e6-67c5-4780-beef-46308a52252f",
+          "eventActionType": 2,
+          "eaName": "Change Objective"
+        },
+        {
+          "theText": "{-} Les murs qui touchent les murs de tuiles adjacentes ne bloquent pas la ligne de vue, les déplacements et l'adjacence, et n'empêche pas de compter les cases.\r\n{-} Tant qu'elles sont sur des cases d'extérieur :\r\n— Les figurines et les capacités ignorent tous les terrains.\r\n— Au début de chaque activation d'une figurine Rebelle, cette dernière gagne 3 points de déplacement.\r\n— Les figurines Impériales ne peuvent volontairement se déplacer que vers le Nord, le Nord-Ouest, ou le Nord-Est.\r\n{-} Quand une figurine Impériale entre dans une case qui contient un pion Mission neutre, elle subit 2 {H}.\r\n{-} Au début de chaque phase de Statut, la section la plus au sud est retirée et chaque figurine qui était encore dessus est poussée vers la section suivante au nord, tout en subissant {H} et/ou {B} comme indiqué par l'application. La section suivante est ensuite ajoutée. Utilisez des Culs-de-sac (tuiles 18B Base, 12B Lothal) si nécessaire.\r\n{-} La mission évolue quand les Rebelles atteignent la navette.\r\n{-} Les Rebelles perdent quand tous les héros sont blessés.",
+          "GUID": "8c69b6b4-590a-4e4b-9252-5dbdddc817ac",
+          "eventActionType": 1,
+          "eaName": "Change Mission Info"
+        }
+      ]
+    },
+    {
+      "eventName": "End of Mission - Rebels win",
+      "GUID": "69b80fad-5e0e-46cd-a70e-defa45de4db6",
+      "eventText": "Des étincelles jaillissent des consoles de la navette et les moteurs lâchent. Les plans et les armes de la résistance Twi'lek sont sauvés !\r\n\r\n{-} Les Rebelles remportent la mission !\r\n{-} Si vous jouez cette mission en tant que mission annexe, les joueurs reçoivent 1 allié Spectre de leur choix en tant qu'allié.",
+      "eventActions": [
+        {
+          "mainText": "Jouez-vous cette mission dans le cadre de la mini-campagne \"Tyrans de Lothal\" ?",
+          "buttonList": [
+            {
+              "GUID": "6ef05728-df0d-4a43-8b55-d9d0974c1684",
+              "theText": "Oui"
+            },
+            {
+              "GUID": "bb54fa03-d81f-417b-983b-89bb9652bc8e",
+              "theText": "Non"
+            }
+          ],
+          "GUID": "fa160c96-ff1c-4306-ad5f-f40d51ef9331",
+          "eventActionType": 5,
+          "eaName": "Question Prompt"
+        }
+      ]
+    },
+    {
+      "eventName": "End of Mission - Rebels lose",
+      "GUID": "9e960fce-d271-468c-8d6c-233bc752aa52",
+      "eventText": "L'ennemi vous est supérieur en puissance de feu et vous demandez votre extraction tandis que la navette Impériale s'échappe. La vue du Phantom vous fait chaud au cœur, bien que Ryloth subira les conséquences de votre échec.\r\n\r\n{-} Les Rebelles perdent la mission.",
+      "eventActions": [
+        {
+          "mainText": "Jouez-vous cette mission dans le cadre de la mini-campagne \"Tyrans de Lothal\" ?",
+          "buttonList": [
+            {
+              "GUID": "54077d80-16f6-47b5-9a41-b72ca0244405",
+              "theText": "Oui"
+            },
+            {
+              "GUID": "819a6aed-da70-4548-bc9a-3fde09ed37f8",
+              "theText": "Non"
+            }
+          ],
+          "GUID": "922d0b18-3b9c-4426-b8b1-9d79afd7d873",
+          "eventActionType": 5,
+          "eaName": "Question Prompt"
+        }
+      ]
+    },
+    {
+      "eventName": "Mini campaign Win",
+      "GUID": "1fb0c0b1-7388-42f6-9c4c-801de27f03a5",
+      "eventText": "Un escadron de chasseurs de la résistance Twi'lek fait irruption pour récupérer son matériel et ses plans aussi vite que possible. Lorsque vous entendez les mugissements distants des TIE, vous êtes déjà en route pour rejoindre l'abri rebelle le plus proche.\r\n\r\nNi vous ni les rebelles Twi'lek ne pouvez vous accorder le luxe de véritables festivités, mais vous êtes chaleureusement accueillis dans leur refuge avant votre prochain rendez-vous avec le Ghost.\r\n\r\n{-} Chaque héros reçoit 3 XP.\r\n{-} Les héros reçoivent 300 crédits par héros.\r\n{-} Les joueurs Rebelles choisissent I héros qui reçoit la carte Récompense \"Cavalier d'élite\".",
+      "eventActions": [
+        {
+          "mainText": "Veuillez sélectionner la bonne option :\r\n\r\n{-} Campagne étendue : vous jouez la mini-campagne étendue avec l'extension de figurine \"Thrawn\".\r\n{-} Mini-campagne : vous jouez la mini-campagne \"Tyrans de Lothal\" sans l'extension de figurine.",
+          "buttonList": [
+            {
+              "GUID": "1b2e12df-e4e9-4256-ab4a-f4b18b9b7925",
+              "theText": "Campagne étendue"
+            },
+            {
+              "GUID": "db242c7b-fdf8-4c91-ac19-a557df168bac",
+              "theText": "Mini-campagne"
+            }
+          ],
+          "GUID": "d93f8f65-094a-440f-bd2c-2849d9099137",
+          "eventActionType": 5,
+          "eaName": "Question Prompt"
+        }
+      ]
+    },
+    {
+      "eventName": "Mini campaign Defeat",
+      "GUID": "ee9e6f21-9b9f-47ca-b982-44b59453a837",
+      "eventText": "Un groupe de Twi'lek rebelle vous aide à couvrir votre retraite tandis que la navette Impériale atteint son orbite. Vous vous éloignez hors de portée sans déplorer de nouvelles pertes, mais vous rentrez les mains vides. Les Twi'lek vous remercient de votre soutien alors même qu'ils se préparent à évacuer.\r\n\r\nVous vous présentez en retard au rendez-vous. Hera est soulagée de vous voir. \"Nous avons perdu assez d'amis pour savoir quand nous devons nous inquiéter\", explique-t-elle.\r\n\r\n{-} Chaque héros reçoit 3 XP.\r\n{-} Les héros reçoivent 300 crédits par héros.",
+      "eventActions": [
+        {
+          "mainText": "Veuillez sélectionner la bonne option :\r\n\r\n{-} Campagne étendue : vous jouez la mini-campagne étendue avec l'extension de figurine \"Thrawn\".\r\n{-} Mini-campagne : vous jouez la mini-campagne \"Tyrans de Lothal\" sans l'extension de figurine.",
+          "buttonList": [
+            {
+              "GUID": "df2bbdde-1c4b-43cf-84ca-0f2f69268e85",
+              "theText": "Campagne étendue"
+            },
+            {
+              "GUID": "1a09516b-b6d0-4b58-98a7-eeb26a6ed4ae",
+              "theText": "Mini-campagne"
+            }
+          ],
+          "GUID": "c47a75a7-d9d7-4f27-ab49-39ee814934b8",
+          "eventActionType": 5,
+          "eaName": "Question Prompt"
+        }
+      ]
+    },
+    {
+      "eventName": "No campaign",
+      "GUID": "8fe1b24a-487b-46a0-9e81-94329508e0dc",
+      "eventText": "{-} Chaque héros reçoit 1 XP.\r\n{-} Les héros reçoivent 100 crédits par héros.",
+      "eventActions": []
+    },
+    {
+      "eventName": "Extended campaign 1",
+      "GUID": "2f95d44b-fe49-4580-aed5-8b4db04f67d8",
+      "eventText": "Thrawn vous suit à la trace depuis que vous avez rejoint les Spectres. Vous êtes certains de ne pas avoir révélé les coordonnées de ces derniers, mais cela commence à devenir un véritable problème. Le genre qu'il vous faudra résoudre si vous voulez garder une longueur d'avance sur Thrawn.\r\n\r\nN-4M, votre contact sur Lothal, vous apporte de bonnes nouvelles. \"J'ai fait l'acquisition de quelques codes d'accès Impériaux\", vous informe le droïde. \"Je pense qu'ils vous donneront accès à un lieu bien précis : la baie d'amarrage secondaire du destroyer stellaire Chimaera.\" N-4M n'a pas besoin d'expliquer en quoi ces informations peuvent être utiles. Les droïdes d'infiltration de Thrawn sont contrôlés depuis ce vaisseau amiral. Une frappe chirurgicale au cœur de l'appareil pourrait vous permettre de respirer un peu.\r\n\r\n{-} La prochaine mission active est \"La poigne de l'amiral\" (extension de figurine antagoniste Thrawn).",
+      "eventActions": []
+    },
+    {
+      "eventName": "Regular mini campaign",
+      "GUID": "5912594d-6f76-449a-8572-5004d336bdd9",
+      "eventText": "Un débat fait rage dans la salle commune du Ghost et vous l'entendez bien avant de le voir. \"Cela pourrait être notre meilleure chance de porter le combat sur le terrain de Thrawn\", insista Ezra tandis qu'il montrait une représentation holographique de Lothal et des nombreux destroyers stellaires qui gravitaient sur son orbite. \"Je sais que cela pourrait être un piège, mais si ce n'en était pas un ? Nous avons travaillé dur pour trouver une brèche qui nous permettrait de répondre aux attaques de Thrawn.\"\r\n\r\nVous les interrompez pour connaître l'objet de leur dispute.\r\n\r\n\"Un ingénieur Impérial nous a envoyé un message\", répond Kanan. \"Il veut déserter, et il prétend pouvoir nous introduire dans la chambre des données qui contient toutes les informations collectées par les droïdes d'infiltration de Thrawn.\" Lorsque le masque de Kanan se tourne dans votre direction, vous ne pouvez qu'imaginer son regard lourd de sens. \"Ces données lui donnent un avantage sur la Rébellion. Mais croire que quelqu'un nous laissera rentrer ? Cela semble trop beau pour être vrai.\"\r\n\r\n\"Nous n'aurons même pas l'occasion d'atterrir avec les gorilles de Thrawn partout dans les parages\", commente Zeb. \"Tous les Impériaux du secteur savent probablement à quoi nous ressemblons.\"\r\n\r\nVous faites un pas en avant. Les Spectres sont une pièce maîtresse de la Rébellion. Ils ne peuvent pas se permettre de prendre un tel risque. Mais vous, vous le pouvez.\r\n\r\n{-} La prochaine mission active est \"L'ordre final\".",
+      "eventActions": []
+    },
+    {
+      "eventName": "End of Round 1",
+      "GUID": "a8a343c6-3908-4130-a884-40fc1ff64947",
+      "eventText": "La course continue et vos blurrgs foncent droit devant.\r\n\r\n{-} Chaque figurine Impériale sur la section extérieure la plus au sud subit 2 {H}, chaque figurine Rebelle sur la section extérieure la plus au sud subit 4 {C}, ensuite chacune de ces figurines est poussée vers la case la plus proche de la section suivante.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "DP Yellow 1",
+              "GUID": "6f1b43d5-51c1-43f3-a528-21c871a26b4b",
+              "theText": null,
+              "buttonList": []
+            },
+            {
+              "entityName": "DP Yellow 2",
+              "GUID": "d7308964-ea6c-4ac0-a467-dee838cd4aab",
+              "theText": null,
+              "buttonList": []
+            },
+            {
+              "entityName": "DP Yellow 3",
+              "GUID": "b7833b28-c2b2-41af-822b-8681428d3e34",
+              "theText": null,
+              "buttonList": []
+            },
+            {
+              "entityName": "DP Yellow 4",
+              "GUID": "9da14ada-5744-4405-9a57-cf464d1ddca9",
+              "theText": null,
+              "buttonList": []
+            }
+          ],
+          "GUID": "08bb3c3e-d73e-4984-b954-34d08df1bff6",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "End of Round 2",
+      "GUID": "269288ab-9103-40b0-b146-ac9fc05ad666",
+      "eventText": "La course continue et vos blurrgs foncent droit devant.\r\n\r\n{-} Chaque figurine Impériale sur la section extérieure la plus au sud subit 2 {H}, chaque figurine Rebelle sur la section extérieure la plus au sud subit 4 {C}, ensuite chacune de ces figurines est poussée vers la case la plus proche de la section suivante.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "DP Purple 1",
+              "GUID": "d0d1a67b-a1b9-44f3-bae5-04daffee8170",
+              "theText": null,
+              "buttonList": []
+            },
+            {
+              "entityName": "DP Purple 2",
+              "GUID": "98737f27-299a-48ea-84ad-d1439a25cc84",
+              "theText": null,
+              "buttonList": []
+            },
+            {
+              "entityName": "DP Purple 3",
+              "GUID": "97429571-44e3-4db2-a9a6-36dd6e154b7c",
+              "theText": null,
+              "buttonList": []
+            },
+            {
+              "entityName": "DP Purple 4",
+              "GUID": "8953270c-f1f8-46fe-8a09-3ba43bf7f9dd",
+              "theText": null,
+              "buttonList": []
+            }
+          ],
+          "GUID": "437691fd-e38a-4f05-9252-c30b9feef907",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "End of Round 3",
+      "GUID": "082b1133-847c-4439-9f5b-1aa3542c8f67",
+      "eventText": "La course continue et vos blurrgs foncent droit devant.\r\n\r\n{-} Chaque figurine Impériale sur la section extérieure la plus au sud subit 2 {H}, chaque figurine Rebelle sur la section extérieure la plus au sud subit 4 {C}, ensuite chacune de ces figurines est poussée vers la case la plus proche de la section suivante.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "DP Blue 1",
+              "GUID": "21d0a660-9ac7-4975-8668-3043778ad65b",
+              "theText": null,
+              "buttonList": []
+            },
+            {
+              "entityName": "DP Blue 2",
+              "GUID": "668fbebb-f2ca-4209-abf0-67eef354fc72",
+              "theText": null,
+              "buttonList": []
+            },
+            {
+              "entityName": "DP Blue 3",
+              "GUID": "258f4424-1d23-4bc5-8a41-ffe7b2142bda",
+              "theText": null,
+              "buttonList": []
+            },
+            {
+              "entityName": "DP Blue 4",
+              "GUID": "91f666ba-bf26-4f80-8356-5ff912451ac0",
+              "theText": null,
+              "buttonList": []
+            }
+          ],
+          "GUID": "bf8eba0d-75f0-4966-8468-76c1dac8c728",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "End of Round 4",
+      "GUID": "e7af48dd-b741-4abb-bdbf-431e221b0b0f",
+      "eventText": "Vos blurrgs grognent lorsque la navette est enfin en vue. D'un bond puissant, ils se précipitent vers le vaisseau dont les moteurs sont déjà en marche, prêts à décoller. Vous n'avez pas beaucoup de temps.\r\n\r\n{-} Chaque figurine Impériale sur la section extérieure la plus au sud subit 2 {H}, chaque figurine Rebelle sur la section extérieure la plus au sud subit 4 {C}, ensuite chacune de ces figurines est poussée vers la case la plus proche de la section suivante.",
+      "eventActions": [
+        {
+          "tbText": "Pour entrer sur la baie d'atterrissage de la navette, vous devrez faire un saut de la foi avec votre blurrg, et il n'y aura pas de retour possible.\r\n\r\n{-} Les figurines à bord de la navette ne peuvent pas quitter la navette.",
+          "GUID": "56afaaa0-8c54-4471-a54c-3122a16260cc",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "tbText": "Par l'écoutille ouverte, on peut voir les consoles de commande du moteur.",
+          "GUID": "bc6b4b5d-9b67-4d18-acbd-a29a1606e3df",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "DP Red 1",
+              "GUID": "ea1eafd7-b621-4d20-82fa-edb5404585ce",
+              "theText": null,
+              "buttonList": []
+            },
+            {
+              "entityName": "DP Red 2",
+              "GUID": "ad897221-9318-438f-9246-d1683b2bc60b",
+              "theText": null,
+              "buttonList": []
+            },
+            {
+              "entityName": "DP Red 3",
+              "GUID": "27330cfb-d03a-486b-95e6-8f8c94153d4e",
+              "theText": null,
+              "buttonList": []
+            },
+            {
+              "entityName": "Engine Control 1",
+              "GUID": "df7b1bd4-e66d-48c2-b6cd-85497b1ac106",
+              "theText": "La console de commande du moteur ronronne doucement.\r\n\r\n{-} Une figurine Rebelle peut attaquer un terminal (Santé : *2*, Défense : 1 {G). Appliquez +1 {G} aux résultats de défense si une figurine Impériale est sur le terminal ou adjacente à ce dernier.",
+              "buttonList": [
+                {
+                  "GUID": "57e93c5a-fd6c-42dc-b8e8-af260c0f38c7",
+                  "theText": "Détruire"
+                }
+              ]
+            },
+            {
+              "entityName": "Engine Control 2",
+              "GUID": "b085a88a-6c84-411c-819b-a9855cfea052",
+              "theText": "La console de commande du moteur ronronne doucement.\r\n\r\n{-} Une figurine Rebelle peut attaquer un terminal (Santé : *2*, Défense : 1 {G). Appliquez +1 {G} aux résultats de défense si une figurine Impériale est sur le terminal ou adjacente à ce dernier.",
+              "buttonList": [
+                {
+                  "GUID": "2aea8774-4669-4379-8cfa-f9ab294fec46",
+                  "theText": "Détruire"
+                }
+              ]
+            }
+          ],
+          "GUID": "11987808-9a2d-418d-9641-19bead9c00cf",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        },
+        {
+          "tbText": "{-} Une figurine Rebelle peut attaquer un terminal (Santé : *2*, Défense : 1 {G). Appliquez +1 {G} aux résultats de défense si une figurine Impériale est sur le terminal ou adjacente à ce dernier.\r\n{-} Les Rebelles gagnent quand les deux terminaux sont détruits.",
+          "GUID": "626cd3b2-a871-49b9-869e-0ecfb2c22936",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "repositionText": "{-} Les figurines hors de la navette : Se déplacer vers la navette. Autant que possible, éviter les pions Mission neutres.\r\n{-} Les figurines dans la navette : Bloquer l'accès aux terminaux.",
+          "GUID": "f9197676-b7b4-449d-83c9-4aeb108b7c1e",
+          "eventActionType": 17,
+          "eaName": "Change Reposition Instructions"
+        },
+        {
+          "shortText": "Détruire les terminaux (&Engines destroyed&/2).",
+          "longText": "",
+          "GUID": "248e87c0-85e7-418e-ac71-026faa651e20",
+          "eventActionType": 2,
+          "eaName": "Change Objective"
+        },
+        {
+          "theText": "{-} Les murs qui touchent les murs de tuiles adjacentes ne bloquent pas la ligne de vue, les déplacements et l'adjacence, et n'empêche pas de compter les cases.\r\n{-} Tant qu'elles sont sur des cases d'extérieur :\r\n— Les figurines et les capacités ignorent tous les terrains.\r\n— Au début de chaque activation d'une figurine Rebelle, cette dernière gagne 3 points de déplacement.\r\n— Les figurines Impériales ne peuvent volontairement se déplacer que vers le Nord, le Nord-Ouest, ou le Nord-Est.\r\n{-} Quand une figurine Impériale entre dans une case qui contient un pion Mission neutre, elle subit 2 {H}.\r\n{-} Les figurines à bord de la navette ne peuvent pas quitter la navette.\r\n{-} Une figurine Rebelle peut attaquer un terminal (Santé : *2*, Défense : 1 {G). Appliquez +1 {G} aux résultats de défense si une figurine Impériale est sur le terminal ou adjacente à ce dernier.\r\n{-} Les Rebelles gagnent quand les deux terminaux sont détruits.\r\n{-} Les Rebelles perdent quand tous les héros sont blessés.",
+          "GUID": "df53c9c1-2184-4b95-ab60-d8fb8db2c580",
+          "eventActionType": 1,
+          "eaName": "Change Mission Info"
+        }
+      ]
+    },
+    {
+      "eventName": "Reinforcements",
+      "GUID": "5008d0b4-4645-4572-9f30-667f4b172576",
+      "eventText": "De nouvelles forces se joignent à la course vers la navette, essayant de vous empêcher de l'atteindre.",
+      "eventActions": []
+    },
+    {
+      "eventName": "The Race is on",
+      "GUID": "1aa13ae0-0dc6-476c-ac3a-eca9779e458b",
+      "eventText": "",
+      "eventActions": []
+    },
+    {
+      "eventName": "TRIO - Thrawn",
+      "GUID": "874ca51e-d006-42ec-8f9d-f466018e94a0",
+      "eventText": "Dans un rugissement de moteurs à répulsion, un airspeeder s'élance à travers le canyon. Sur le siège de l'artilleur, vous voyez nul autre que Thrawn lui-même.",
+      "eventActions": [
+        {
+          "enemyName": null,
+          "customText": "",
+          "modification": "+*2* Santé",
+          "repositionInstructions": "",
+          "GUID": "713fe77a-9f72-400d-8efa-49a6a1f53548",
+          "eventActionType": 6,
+          "eaName": "Deploy: DG085/Thrawn"
+        },
+        {
+          "tbText": "D'autres motojets aux moteurs rugissants arrivent.",
+          "GUID": "c651e946-7238-4669-bffd-71cfae424b9e",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        }
+      ]
+    },
+    {
+      "eventName": "TRIO - Hondo",
+      "GUID": "640314a6-bad0-41b8-9804-3d1e41578b43",
+      "eventText": "\"C'est un vrai plaisir de nous rencontrer à nouveau !\", dit une voix amplifiée qui résonne à travers les canyons. Par une brèche entre les rochers, une motojet arrive à toute allure. Hondo Ohnaka, son pilote, vous salue joyeusement, puis dégaine un blaster. \"Et c'est si triste que je doive vous arrêter là.\"",
+      "eventActions": [
+        {
+          "enemyName": null,
+          "customText": "",
+          "modification": "+*2* Santé",
+          "repositionInstructions": "",
+          "GUID": "fe08822d-e7c5-4d81-b0fc-60a7cefaf8fb",
+          "eventActionType": 6,
+          "eaName": "Deploy: DG086/Hondo Ohnaka"
+        },
+        {
+          "tbText": "D'autres motojets aux moteurs rugissants arrivent.",
+          "GUID": "862f0425-923d-4e65-8c85-a418e4850abb",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        }
+      ]
+    },
+    {
+      "eventName": "From the Cockpit - Thrawn",
+      "GUID": "880dba3b-cff3-4f40-8f61-e90ca7c30cb9",
+      "eventText": "Sortant du cockpit, les forces de Thrawn se précipitent pour vous arrêter.",
+      "eventActions": [
+        {
+          "enemyName": null,
+          "customText": "",
+          "modification": null,
+          "repositionInstructions": "",
+          "GUID": "f4cd3fb5-87bd-4366-9869-545a063dfd96",
+          "eventActionType": 6,
+          "eaName": "Deploy: DG057/Death Trooper"
+        },
+        {
+          "enemyName": null,
+          "customText": "",
+          "modification": null,
+          "repositionInstructions": "",
+          "GUID": "bf02b83d-b059-44d6-8a38-463138ff34e1",
+          "eventActionType": 6,
+          "eaName": "Deploy: DG058/Death Trooper (Elite)"
+        }
+      ]
+    },
+    {
+      "eventName": "From the Cockpit - Hondo",
+      "GUID": "7ff3e17f-5203-445e-bf15-519a750740e4",
+      "eventText": "Sortant du cockpit, les hommes de main de Hondo se précipitent pour vous arrêter.",
+      "eventActions": [
+        {
+          "enemyName": null,
+          "customText": "",
+          "modification": null,
+          "repositionInstructions": "",
+          "GUID": "bfa9f884-ba42-4c98-864e-3f19f6570c45",
+          "eventActionType": 6,
+          "eaName": "Deploy: DG015/Trandoshan Hunter"
+        }
+      ]
+    },
+    {
+      "eventName": "Engine Control 1 Destroyed",
+      "GUID": "2bdbf013-d03b-44e1-90d7-61312f945ee3",
+      "eventText": "La commande du moteur explose dans une pluie d'étincelles.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Engine Control 1",
+              "GUID": "7db341ff-8ec4-4022-9255-c0a1550d2d6f",
+              "theText": "La console de commande du moteur ronronne doucement.\r\n\r\n{-} Une figurine Rebelle peut attaquer un terminal (Santé : *2*, Défense : 1 {G). Appliquez +1 {G} aux résultats de défense si une figurine Impériale est sur le terminal ou adjacente à ce dernier.",
+              "buttonList": []
+            }
+          ],
+          "GUID": "08dd0b8e-84f4-48d8-bd4a-c09d5dbfdeea",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "Engine Control 2 Destroyed",
+      "GUID": "c4238ad5-1ce5-4137-88ab-4d82a37f0ba5",
+      "eventText": "La commande du moteur explose dans une pluie d'étincelles.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Engine Control 2",
+              "GUID": "70dc2341-3779-40dc-adee-f5e73ebfa5f7",
+              "theText": "La console de commande du moteur ronronne doucement.\r\n\r\n{-} Une figurine Rebelle peut attaquer un terminal (Santé : *2*, Défense : 1 {G). Appliquez +1 {G} aux résultats de défense si une figurine Impériale est sur le terminal ou adjacente à ce dernier.",
+              "buttonList": []
+            }
+          ],
+          "GUID": "dbc34c2e-6941-4d8f-b338-5cfcbea0e6c1",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    }
+  ],
+  "mapEntities": [
+    {
+      "entityName": "Crate1",
+      "GUID": "dcf1e03e-e328-4f79-8427-e0a0bfc64f82",
+      "mainText": "Une vieille caisse de ravitaillement.",
+      "buttonList": [
+        {
+          "GUID": "0afb22f8-0f16-4f75-b1c8-77ee729a5d57",
+          "theText": "{A} Ouvrir"
+        }
+      ]
+    },
+    {
+      "entityName": "Crate2",
+      "GUID": "461e69e0-7c26-42a1-ad2a-a5e71b4f7707",
+      "mainText": "Une vieille caisse de ravitaillement.",
+      "buttonList": [
+        {
+          "GUID": "6c4b9460-0d4b-4701-9172-e37dfd0417a8",
+          "theText": "{A} Ouvrir"
+        }
+      ]
+    },
+    {
+      "entityName": "Crate3",
+      "GUID": "1e60bee2-7e72-4f71-8c0e-45b5a2d0baf8",
+      "mainText": "Une vieille caisse de ravitaillement.",
+      "buttonList": [
+        {
+          "GUID": "51bca86a-4619-4080-a899-28be3d96dd70",
+          "theText": "{A} Ouvrir"
+        }
+      ]
+    },
+    {
+      "entityName": "Entrance",
+      "GUID": "a343a128-3b10-48ff-878f-71c89176d776",
+      "mainText": "Déployer les héros ici.",
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Green 1",
+      "GUID": "c8062d94-a52f-4458-b2cf-3c7b515747e5",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Green 2",
+      "GUID": "5bdffef2-c7c7-4e16-ab66-dca82b0481fd",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Green 3",
+      "GUID": "64b4dbf2-4e39-4ce7-a5fe-94eed25c16d2",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP EOfficer",
+      "GUID": "81ead058-7663-414c-aed5-13a096cc71f9",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Yellow 1",
+      "GUID": "0f0a1cf6-de73-4368-b3c9-972aee4f8c1a",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Yellow 2",
+      "GUID": "3d261a55-015d-4959-874c-aca303b5042a",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Yellow 3",
+      "GUID": "8120f83b-b145-4895-b4ef-e1fce1c97074",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Yellow 4",
+      "GUID": "724c174e-5765-4861-b3e0-cc677ab34bbe",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Purple 1",
+      "GUID": "c87cda9c-0827-49d0-a897-1c862740b9e5",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Purple 2",
+      "GUID": "75130566-d6a4-43e7-968d-7376d10ebc21",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Purple 3",
+      "GUID": "96cb53b4-742a-45a6-9734-c54f6f9f5f50",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Purple 4",
+      "GUID": "e02313ca-7f0f-441f-9b3d-52afa06e69fd",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Blue 1",
+      "GUID": "5a24c0b6-3bbe-400d-99e4-df76cde5bd78",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Blue 2",
+      "GUID": "676cfb87-c55a-4584-a163-377e6140f158",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Blue 3",
+      "GUID": "19150a22-7b09-4e83-99a6-5dde6bbc8aed",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Blue 4",
+      "GUID": "4acd3149-8a3a-4e70-8991-503ff4b9abe6",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Red 1",
+      "GUID": "d0067c02-4aa1-4821-9698-edbc4763d621",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Red 2",
+      "GUID": "b4704c95-b20a-4c46-a64c-2fcc35385779",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Red 3",
+      "GUID": "930e53e8-ad33-4d74-ab4b-0cb4e8819322",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Section 6 1",
+      "GUID": "d1899911-c671-40f9-ba86-b113bdd9518a",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Section 6 2",
+      "GUID": "4c9dc91b-9115-404a-a37e-8f06cbb07c45",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP DTrooper",
+      "GUID": "84bcacb3-5fbc-43ef-bb8b-6a65f0c60db9",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Trooper 1",
+      "GUID": "5bff55b7-2377-4065-9c7c-d8e1b3fda047",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Trooper 2",
+      "GUID": "4dddaf4b-2215-4f83-b54a-81e0c1c87391",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Trooper 3",
+      "GUID": "ae313529-faa2-4f8b-a6b8-62244fafe932",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "Rocks 1",
+      "GUID": "c92fbf62-85de-4c21-a6f3-58e8f6cb81c3",
+      "mainText": "Des rochers sont tombés dans le canyon à cet endroit, bloquant le passage.\r\n\r\n{-} Quand une figurine Impériale entre dans une case qui contient un pion Mission neutre, elle subit 2 {H}.",
+      "buttonList": []
+    },
+    {
+      "entityName": "Rocks 2",
+      "GUID": "aa77aa3e-8a34-4213-b848-488dc22ddde3",
+      "mainText": "Des rochers sont tombés dans le canyon à cet endroit, bloquant le passage.\r\n\r\n{-} Quand une figurine Impériale entre dans une case qui contient un pion Mission neutre, elle subit 2 {H}.",
+      "buttonList": []
+    },
+    {
+      "entityName": "Rocks 3",
+      "GUID": "3ca3d296-b53a-462f-8e4f-0c56e196d093",
+      "mainText": "Des rochers sont tombés dans le canyon à cet endroit, bloquant le passage.\r\n\r\n{-} Quand une figurine Impériale entre dans une case qui contient un pion Mission neutre, elle subit 2 {H}.",
+      "buttonList": []
+    },
+    {
+      "entityName": "Rocks 4",
+      "GUID": "9367e290-9066-416d-a052-375c45451515",
+      "mainText": "Des rochers sont tombés dans le canyon à cet endroit, bloquant le passage.\r\n\r\n{-} Quand une figurine Impériale entre dans une case qui contient un pion Mission neutre, elle subit 2 {H}.",
+      "buttonList": []
+    },
+    {
+      "entityName": "Rocks 5",
+      "GUID": "98980469-82de-4285-b8f1-aad27b6ac423",
+      "mainText": "Des rochers sont tombés dans le canyon à cet endroit, bloquant le passage.\r\n\r\n{-} Quand une figurine Impériale entre dans une case qui contient un pion Mission neutre, elle subit 2 {H}.",
+      "buttonList": []
+    },
+    {
+      "entityName": "Rocks 6",
+      "GUID": "43f99435-f339-4ab2-bc77-bbccadc7772a",
+      "mainText": "Des rochers sont tombés dans le canyon à cet endroit, bloquant le passage.\r\n\r\n{-} Quand une figurine Impériale entre dans une case qui contient un pion Mission neutre, elle subit 2 {H}.",
+      "buttonList": []
+    },
+    {
+      "entityName": "Rocks 7",
+      "GUID": "198a7fc4-8149-4152-8ebd-e4bcba00f3ba",
+      "mainText": "Des rochers sont tombés dans le canyon à cet endroit, bloquant le passage.\r\n\r\n{-} Quand une figurine Impériale entre dans une case qui contient un pion Mission neutre, elle subit 2 {H}.",
+      "buttonList": []
+    },
+    {
+      "entityName": "Engine Control 1",
+      "GUID": "34ff295c-0879-4619-b36a-2a60df0f5c39",
+      "mainText": "La console de commande du moteur ronronne doucement.\r\n\r\n{-} Une figurine Rebelle peut attaquer un terminal (Santé : *2*, Défense : 1 {G). Appliquez +1 {G} aux résultats de défense si une figurine Impériale est sur le terminal ou adjacente à ce dernier.",
+      "buttonList": [
+        {
+          "GUID": "2ef0f366-de34-4374-9207-a1f146009c28",
+          "theText": "Détruire"
+        }
+      ]
+    },
+    {
+      "entityName": "Engine Control 2",
+      "GUID": "eae00198-3e83-403e-984c-f9157fb12190",
+      "mainText": "La console de commande du moteur ronronne doucement.\r\n\r\n{-} Une figurine Rebelle peut attaquer un terminal (Santé : *2*, Défense : 1 {G). Appliquez +1 {G} aux résultats de défense si une figurine Impériale est sur le terminal ou adjacente à ce dernier.",
+      "buttonList": [
+        {
+          "GUID": "6fbc7e7a-e276-4161-afd7-067c7a7e33f3",
+          "theText": "Détruire"
+        }
+      ]
+    }
+  ],
+  "initialGroups": [
+    {
+      "cardName": "Stormtrooper",
+      "customInstructions": ""
+    },
+    {
+      "cardName": "Death Trooper",
+      "customInstructions": ""
+    },
+    {
+      "cardName": "Imperial Officer (Elite)",
+      "customInstructions": ""
+    }
+  ]
+}

--- a/ImperialCommander2/Assets/Resources/Languages/Fr/Missions/Lothal/LOTHAL4_FR.json
+++ b/ImperialCommander2/Assets/Resources/Languages/Fr/Missions/Lothal/LOTHAL4_FR.json
@@ -1,0 +1,824 @@
+{
+  "languageID": "French (FR)",
+  "missionProperties": {
+    "missionName": "Les Dunes de Seelos",
+    "missionDescription": "Si vous jouez une mini-campagne, les héros doivent emmener un allié Spectre qu'ils n'ont pas déjà emmené lors d'une mission de cette mini-campagne. ==== Lorsqu'il apprend que Wolffe, son commandant pendant la Guerre des Clones, est non seulement vivant, mais qu'il s'est allié à la Rébellion, CT-1701 déclare que son équipe est volontaire pour voyager jusqu'à Seelos et ramener les précieuses informations que Wolffe a rassemblées sur son marcheur TB-TT volé. Mais l'Empire arrive en premier et pourchasse le marcheur de Wolffe avec leurs propres machines de guerre blindées...",
+    "missionInfo": "",
+    "campaignName": "Tyrans de Lothal",
+    "startingObjective": "",
+    "repositionOverride": "Bloquer l'accès aux portes.",
+    "additionalMissionInfo": "Si vous jouez une mini-campagne, les héros doivent emmener un allié Spectre qu'ils n'ont pas déjà emmené lors d'une mission de cette mini-campagne."
+  },
+  "events": [
+    {
+      "eventName": "Open Crate 1",
+      "GUID": "2dec36b9-ce77-4bf6-8c35-9489e6573609",
+      "eventText": "Vous fouillez la caisse et prenez ce qui vous semble utile.\r\n\r\nPiochez une carte Ravitaillement. Vous gagnez 1 médipack. Récupérez ce pion.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Crate1",
+              "GUID": "98a39f99-9bdf-4506-8ef8-d70a54017f34",
+              "theText": "Une vieille caisse de ravitaillement.",
+              "buttonList": [
+                {
+                  "GUID": "7e7ef78a-d6dd-4023-8084-602f3bb8ec42",
+                  "theText": "{A} Ouvrir"
+                }
+              ]
+            }
+          ],
+          "GUID": "8eb6c4bb-fd64-4ae8-9b6d-a5ba3f737e6a",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "Open Crate 2",
+      "GUID": "74bbaee9-47db-48c2-b09c-7d0940adf6ab",
+      "eventText": "Vous fouillez la caisse et prenez ce qui vous semble utile.\r\n\r\nPiochez une carte Ravitaillement. Vous gagnez 1 médipack. Récupérez ce pion.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Crate2",
+              "GUID": "d5643609-a8db-4f5c-821a-2ad58a807621",
+              "theText": "Une vieille caisse de ravitaillement.",
+              "buttonList": []
+            }
+          ],
+          "GUID": "a6f06d59-b18c-465a-acc1-85db4a122e25",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "Open Crate 3",
+      "GUID": "4c60aea9-45d0-4dbe-9bea-27d51eba9079",
+      "eventText": "Vous fouillez la caisse et prenez ce qui vous semble utile.\r\n\r\nPiochez une carte Ravitaillement. Vous gagnez 1 médipack. Récupérez ce pion.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Crate3",
+              "GUID": "c8945a77-8c64-4d36-8a90-4b4780e31a2b",
+              "theText": "Une vieille caisse de ravitaillement.",
+              "buttonList": []
+            }
+          ],
+          "GUID": "50b5bf42-216f-45db-925e-d733f34fdd76",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "Mission Briefing",
+      "GUID": "edc56ae0-7e4f-4ecd-9176-26e69bfd835a",
+      "eventText": "Alors que vous approchez des coordonnées que vous avez obtenues de Wolffe, vous voyez le paysage aride de Seelos s'étendre devant vous.",
+      "eventActions": [
+        {
+          "tbText": "D'en haut, les imposantes machines de guerre du désert ont presque l'air de jouets. Votre pilote accélère pour se rapprocher, et bientôt la taille réelle des intimidants marcheurs TB-TT devient évidente.\r\n\r\n{-} Le Champ de bataille (cases d'extérieur) et tous les pions qui s'y trouvent ne peuvent pas être affectés par des effets de carte.",
+          "GUID": "9e5cdd57-ca7e-4958-b834-cb2e983d3648",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Rebel AT-AT",
+              "GUID": "a5d11d81-549b-42d3-aa7e-1406c1f440cf",
+              "theText": null,
+              "buttonList": []
+            }
+          ],
+          "GUID": "c7063f61-1a96-4782-894c-99523a820ac8",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        },
+        {
+          "tbText": "Le marcheur de Wolffe est couvert d'impacts de tirs.  \r\n\r\n{-} Le pion Mission Rebelle représente le TB-TT Rebelle.",
+          "GUID": "148debf2-ccc7-4f80-b8a8-ca31e1dd5088",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "tbText": "Deux autres TB-TT se profilent au loin, derrière le marcheur de Wolffe. Leurs pas lourds semblent lents, mais ils sont à la poursuite de Wolffe, leurs canons allumés.",
+          "GUID": "8e9771aa-7e1d-493f-bf11-b98aec43f537",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Imperial AT-AT 1",
+              "GUID": "5cce025e-6117-4f04-8d60-1cb3cbcb4bf7",
+              "theText": null,
+              "buttonList": []
+            },
+            {
+              "entityName": "Imperial AT-AT 2",
+              "GUID": "53c97387-3b31-4239-9169-9423fb7821dd",
+              "theText": null,
+              "buttonList": []
+            }
+          ],
+          "GUID": "be3bd227-8870-4991-b491-b96d1e14fc9b",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        },
+        {
+          "tbText": "{-} Les pions Mission Impériaux représentent les TB-TT Impériaux.\r\n{-} Les TB-TT ont : Santé : 9, Défense : Aucune, Attaque : {O}, 1 dé bleu, Vitesse : 1.\r\n{-} Les Pions Missions Rebelles sont des figurines Rebelles et les pions Missions Impériaux sont des figurines Impériales.\r\n{-} Les TB-TT Rebelles ne peuvent pas attaquer. \r\n{-} Les TB-TT ne s'activent pas normalement. À la place, à la fin de la phase d'activation, chaque TB-TT Rebelle s'active. Ensuite, chaque TB-TT Impérial s'active.",
+          "GUID": "10dfa0a8-db85-4611-8e38-d074f14626b0",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "tbText": "\"Accrochez-vous !\", dit votre pilote. \"Je descends.\" Votre navette se pose sur un des marcheurs et vous y pénétrez par une trappe d'évacuation.",
+          "GUID": "c93d9492-1f2f-4977-9d0d-8eb79fd8494f",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "tbText": "Vous descendez et devez à présent faire face à un contingent de troupes Impériales au grand complet.\r\n\r\n{-} Déployez les héros sur la case bleue en surbrillance.",
+          "GUID": "af2a2205-73db-4170-a9f2-0749d9800829",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "enemyName": null,
+          "customText": "",
+          "modification": null,
+          "repositionInstructions": "",
+          "GUID": "bc186a0b-e449-43fa-a181-a566d7cdde5e",
+          "eventActionType": 6,
+          "eaName": "Deploy: DG001/Stormtrooper"
+        },
+        {
+          "enemyName": null,
+          "customText": "",
+          "modification": null,
+          "repositionInstructions": "",
+          "GUID": "b252ddff-d004-457d-adeb-192ea150e815",
+          "eventActionType": 6,
+          "eaName": "Deploy: DG004/Imperial Officer"
+        },
+        {
+          "enemyName": null,
+          "customText": "",
+          "modification": null,
+          "repositionInstructions": "",
+          "GUID": "0e89fab0-438f-4d56-8961-f49478ddae3e",
+          "eventActionType": 6,
+          "eaName": "Deploy: DG056/Death Trooper"
+        },
+        {
+          "tbText": "Si vous voulez donner à Wolffe une chance de se battre, vous devez vous emparer de ce marcheur dès que possible.\r\n\r\n{-} La mission évolue quand les Rebelles atteignent le cockpit.\r\n{-} Quand un TB-TT Rebelle est vaincu, cliquez sur la case en surbrillance du Champ de bataille (cases d'extérieur) et sélectionnez \"TB-TT Rebelle vaincu\".\r\n{-} Les Rebelles perdent quand un TB-TT Rebelle est vaincu, ou quand tous les héros sont blessés.",
+          "GUID": "560fafe8-2aeb-4b58-a583-5c211a581a32",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Rebel AT-AT",
+              "GUID": "89237206-9c70-453f-b729-15b106d71483",
+              "theText": null,
+              "buttonList": []
+            },
+            {
+              "entityName": "Imperial AT-AT 1",
+              "GUID": "81a5b19e-4e71-4f83-b906-2985f5acb1e2",
+              "theText": null,
+              "buttonList": []
+            },
+            {
+              "entityName": "Imperial AT-AT 2",
+              "GUID": "8af30721-51ff-4f2a-8e88-0632cb662d47",
+              "theText": null,
+              "buttonList": []
+            },
+            {
+              "entityName": "AT-AT Highlight",
+              "GUID": "d2a3bd4e-a157-46f8-8660-2c42c9de5c7a",
+              "theText": "Quand un TB-TT Rebelle est vaincu, cliquez sur \"TB-TT Rebelle vaincu\".",
+              "buttonList": [
+                {
+                  "GUID": "a7e27db3-ee71-4788-a785-08384dac85dd",
+                  "theText": "TB-TT Rebelle vaincu"
+                }
+              ]
+            }
+          ],
+          "GUID": "2592d3a3-ef02-4c50-b2ef-27ecbbccc6c6",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        },
+        {
+          "shortText": "Atteindre le cockpit.",
+          "longText": null,
+          "GUID": "f31b9a3b-28b4-4f8c-a2d0-e3a3c45e64d5",
+          "eventActionType": 2,
+          "eaName": "Change Objective"
+        },
+        {
+          "theText": "{-} Le Champ de bataille (cases d'extérieur) et tous les pions qui s'y trouvent ne peuvent pas être affectés par des effets de carte.\r\n{-} Le pion Mission Rebelle représente le TB-TT Rebelle.\r\n{-} Les pions Mission Impériaux représentent les TB-TT Impériaux.\r\n{-} Les TB-TT ont : Santé : 9, Défense : Aucune, Attaque : {O}, 1 dé bleu, Vitesse : 1.\r\n{-} Les Pions Missions Rebelles sont des figurines Rebelles et les pions Missions Impériaux sont des figurines Impériales.\r\n{-} Les TB-TT Rebelles ne peuvent pas attaquer. \r\n{-} Les TB-TT ne s'activent pas normalement. À la place, à la fin de la phase d'activation, chaque TB-TT Rebelle s'active. Ensuite, chaque TB-TT Impérial s'active.\r\n{-} La mission évolue quand les Rebelles atteignent le cockpit.\r\n{-} Quand un TB-TT Rebelle est vaincu, cliquez sur la case en surbrillance du Champ de bataille (cases d'extérieur) et sélectionnez \"TB-TT Rebelle vaincu\".\r\n{-} Les Rebelles perdent quand un TB-TT Rebelle est vaincu, ou quand tous les héros sont blessés.",
+          "GUID": "52795fcb-08c7-44a4-94d8-e7519eb9fd2d",
+          "eventActionType": 1,
+          "eaName": "Change Mission Info"
+        }
+      ]
+    },
+    {
+      "eventName": "End of Mission - Rebels win",
+      "GUID": "69b80fad-5e0e-46cd-a70e-defa45de4db6",
+      "eventText": "Le marcheur Impérial explose telle une boule de feu. Les commandants clones sont de nouveau en sécurité.\r\n\r\n{-} Les Rebelles remportent la mission !",
+      "eventActions": [
+        {
+          "mainText": "Jouez-vous cette mission dans le cadre de la mini-campagne \"Tyrans de Lothal\" ?",
+          "buttonList": [
+            {
+              "GUID": "79e23f30-9b9c-4823-bb3a-d16396d9a092",
+              "theText": "Oui"
+            },
+            {
+              "GUID": "42245da9-e0ad-414a-884e-d83e9ebd3d74",
+              "theText": "Non"
+            }
+          ],
+          "GUID": "fa160c96-ff1c-4306-ad5f-f40d51ef9331",
+          "eventActionType": 5,
+          "eaName": "Question Prompt"
+        }
+      ]
+    },
+    {
+      "eventName": "End of Mission - Rebels lose",
+      "GUID": "9e960fce-d271-468c-8d6c-233bc752aa52",
+      "eventText": "Vous devez vous replier vers votre navette. Au moment de décoller, une rafale de tir en provenance d'un marcheur Impérial fauche une des pattes du TB-TT des commandants clones qui s'effondre au sol.\r\n\r\n{-} Les Rebelles perdent la mission.",
+      "eventActions": [
+        {
+          "mainText": "Jouez-vous cette mission dans le cadre de la mini-campagne \"Tyrans de Lothal\" ?",
+          "buttonList": [
+            {
+              "GUID": "e04d0b57-8803-4051-bcba-b21e0d7e8289",
+              "theText": "Oui"
+            },
+            {
+              "GUID": "dca505c2-3a29-4625-8f57-1db287b1e93c",
+              "theText": "Non"
+            }
+          ],
+          "GUID": "922d0b18-3b9c-4426-b8b1-9d79afd7d873",
+          "eventActionType": 5,
+          "eaName": "Question Prompt"
+        }
+      ]
+    },
+    {
+      "eventName": "Mini campaign Win",
+      "GUID": "1fb0c0b1-7388-42f6-9c4c-801de27f03a5",
+      "eventText": "Wolffe rentre en contact avec vous et vous transmet les codes qu'ils ont volés sur une fréquence codée. Le clone grisonnant paraît presque jovial. \"Je connais des tas de ferraille plus coriaces que ces nouveaux troopers. On vous doit une fière chandelle, gamin.\"\r\n\r\nLors du rendez-vous que vous aviez organisé avec les Spectres, ces derniers apprennent avec plaisir que Wolfe et Gregor sont en sécurité.\r\n\r\nSabine vérifie les codes volés par Wolfe. \"Nous allons pouvoir les utiliser pendant un bon bout de temps avant que les Impériaux ne s'en aperçoivent\", annonce-t-elle.\r\n\r\n{-} Chaque héros reçoit 3 XP.\r\n{-} Les héros reçoivent 300 crédits par héros.",
+      "eventActions": [
+        {
+          "mainText": "Veuillez sélectionner la bonne option :\r\n\r\n{-} Campagne étendue 1 : vous jouez la mini-campagne étendue avec l'extension de figurines \"Ezra Bridger et Kanan Jarrus\".\r\n{-} Campagne étendue 2 : vous jouez la mini-campagne étendue avec l'extension de figurines \"Sabine Wren et Zeb Orrelios\".\r\n{-} Campagne étendue 3 : vous jouez la mini-campagne étendue avec ces deux extensions de figurines.\r\n{-} Mini-campagne : vous jouez la mini-campagne \"Tyrans de Lothal\" sans aucune de ces deux extensions de figurine.",
+          "buttonList": [
+            {
+              "GUID": "9d3b40b7-6b49-4f27-9f43-45f8c387c6d3",
+              "theText": "Campagne étendue 1"
+            },
+            {
+              "GUID": "4af18656-a2f8-448c-bc39-90c94a83a885",
+              "theText": "Campagne étendue 2"
+            },
+            {
+              "GUID": "29bfbf8b-b6b4-4d09-a327-0cd15b18233b",
+              "theText": "Campagne étendue 3"
+            },
+            {
+              "GUID": "066f28b3-950e-4fc9-a4ab-fc4a55f9c440",
+              "theText": "Mini-campagne"
+            }
+          ],
+          "GUID": "d93f8f65-094a-440f-bd2c-2849d9099137",
+          "eventActionType": 5,
+          "eaName": "Question Prompt"
+        }
+      ]
+    },
+    {
+      "eventName": "Mini campaign Defeat",
+      "GUID": "ee9e6f21-9b9f-47ca-b982-44b59453a837",
+      "eventText": "Vous faites profil bas pendant à peu près une semaine en attendant votre prochain rendez-vous avec le Ghost. Les Spectres font grise mine en apprenant les nouvelles. Ezra est le premier à rompre le silence. \r\n\r\n\"Wolffe et Gregor ont survécu à la Guerre des Clones. Ils sauront survivre à cela.\"\r\n\r\n\"Nous aurions tous dû être là\", grogne Zeb.\r\n\r\n\"Je suis sûr que tout le monde a fait ce qu'il a pu\", répond Hera.\r\n\r\n{-} Chaque héros reçoit 3 XP.\r\n{-} Les héros reçoivent 300 crédits par héros.",
+      "eventActions": [
+        {
+          "mainText": "Veuillez sélectionner la bonne option :\r\n\r\n{-} Campagne étendue 1 : vous jouez la mini-campagne étendue avec l'extension de figurines \"Ezra Bridger et Kanan Jarrus\".\r\n{-} Campagne étendue 2 : vous jouez la mini-campagne étendue avec l'extension de figurines \"Sabine Wren et Zeb Orrelios\".\r\n{-} Campagne étendue 3 : vous jouez la mini-campagne étendue avec ces deux extensions de figurines.\r\n{-} Mini-campagne : vous jouez la mini-campagne \"Tyrans de Lothal\" sans aucune de ces deux extensions de figurine.",
+          "buttonList": [
+            {
+              "GUID": "20c4cb6c-a9cf-49c7-ace4-f07dccc38bfb",
+              "theText": "Campagne étendue 1"
+            },
+            {
+              "GUID": "07eed054-933c-41c2-b6b6-039ef06a1971",
+              "theText": "Campagne étendue 2"
+            },
+            {
+              "GUID": "70d5e00d-ec89-45d7-9b56-15107d9cb1fc",
+              "theText": "Campagne étendue 3"
+            },
+            {
+              "GUID": "f090acbe-3116-4e5a-a317-e2145fed9418",
+              "theText": "Mini-campagne"
+            }
+          ],
+          "GUID": "c47a75a7-d9d7-4f27-ab49-39ee814934b8",
+          "eventActionType": 5,
+          "eaName": "Question Prompt"
+        }
+      ]
+    },
+    {
+      "eventName": "No campaign",
+      "GUID": "8fe1b24a-487b-46a0-9e81-94329508e0dc",
+      "eventText": "{-} Chaque héros reçoit 1 XP.\r\n{-} Les héros reçoivent 100 crédits par héros.",
+      "eventActions": []
+    },
+    {
+      "eventName": "Extended campaign 1",
+      "GUID": "2f95d44b-fe49-4580-aed5-8b4db04f67d8",
+      "eventText": "\"Nous faisons profil bas\", vous informe Hera. Ce dont nous avons le plus besoin à présent, c'est de quelque chose pour distraire Thrawn.\"\r\n\r\nVotre contact sur Lothal, le droïde N-4M, est heureux d'entendre de vos nouvelles. Enfin, aussi heureux que puisse l'être un droïde analyste. \"Vous avez mis la garnison locale dans un léger embarras. Ils se préparent à faire face à une possible attaque de plus grande ampleur de la part des Rebelles.\"\r\n\r\nN-4M met de côté son holoprojecteur pour se concentrer sur la surface de Lothal. \"L'Empire exploite ses travailleurs forcés encore plus durement que d'habitude. Un officier en particulier, le Colonel Xarok, jouit d'une réputation de plus en plus mauvaise. Il semble que ses pratiques soient particulièrement... agressives.\"\r\n\r\n{-} La prochaine mission active est \"Abus de l'exécutif\" (extension de figurines allié Ezra et Kanan).",
+      "eventActions": []
+    },
+    {
+      "eventName": "Extended campaign 2",
+      "GUID": "fbdc139d-95c5-421b-9b4a-ace4b3010a6b",
+      "eventText": "\"Nous faisons profil bas\", vous informe Hera. Ce dont nous avons le plus besoin à présent, c'est de quelque chose pour distraire Thrawn.\"\r\n\r\nVotre contact sur Lothal, le droïde N-4M, est heureux d'entendre de vos nouvelles. Enfin, aussi heureux que puisse l'être un droïde analyste. \"Vous avez mis la garnison locale dans un léger embarras. Ils se préparent à faire face à une possible attaque de plus grande ampleur de la part des Rebelles.\"\r\n\r\nN-4M sort un schéma des routes de ravitaillement Impériales menant vers Lothal. \"Plusieurs travailleurs wookies se sont rebellés récemment dans un camp directement lié aux activités de Thrawn. Leur soulèvement a échoué et l'Empire menace à présent leurs familles de représailles. Peut-être pourriez-vous intervenir en faveur des Wookies ?\"\r\n\r\n{-} La prochaine mission active est \"Facteur d'intimidation\" (extension de figurines allié Sabine et Zeb).",
+      "eventActions": []
+    },
+    {
+      "eventName": "Extended campaign 3",
+      "GUID": "3b320c43-2936-47f5-8dab-d5677138c38d",
+      "eventText": "\"Nous faisons profil bas\", vous informe Hera. Ce dont nous avons le plus besoin à présent, c'est de quelque chose pour distraire Thrawn.\"\r\n\r\nVotre contact sur Lothal, le droïde N-4M, est heureux d'entendre de vos nouvelles. Enfin, aussi heureux que puisse l'être un droïde analyste. \"Vous avez mis la garnison locale dans un léger embarras. Ils se préparent à faire face à une possible attaque de plus grande ampleur de la part des Rebelles.\"\r\n\r\nN-4M met de côté son holoprojecteur pour se concentrer sur la surface de Lothal. \"L'Empire exploite ses travailleurs forcés encore plus durement que d'habitude. Un officier en particulier, le Colonel Xarok, jouit d'une réputation de plus en plus mauvaise. Il semble que ses pratiques soient particulièrement... agressives.\"\r\n\r\nN-4M sort un schéma des routes de ravitaillement Impériales menant vers Lothal. \"Plusieurs travailleurs wookies se sont rebellés récemment dans un camp directement lié aux activités de Thrawn. Leur soulèvement a échoué et l'Empire menace à présent leurs familles de représailles. Peut-être pourriez-vous intervenir en faveur des Wookies ?\"\r\n\r\n{-} Les héros choisissent collectivement s'ils souhaitent attaquer le Colonel Xarok ou s'ils préfèrent aider les Wookies.\r\n{-} Si les héros choisissent d'attaquer le colonel Xarok, la prochaine mission active est \"Abus de l'exécutif\" (extension de figurines allié Ezra et Kanan).\r\n{-} Si les héros choisissent d'aider les Wookies, la prochaine mission active est \"Facteur d'intimidation\" (extension de figurines allié Sabine et Zeb).",
+      "eventActions": []
+    },
+    {
+      "eventName": "Regular mini campaign",
+      "GUID": "5912594d-6f76-449a-8572-5004d336bdd9",
+      "eventText": "À bord du Ghost, vous trouvez Hera et Sabine en train d'étudier les restes d'un droïde infiltrateur E-XD. Nous nous sommes aperçues que plusieurs de ces choses tentaient de nous suivre dernièrement\", commenta Hera. \"Et Thrawn n'a pas encore abandonné. Nous devons jouer à armes égales.\"\r\n\r\n\"Alors, donnons-lui d'autres sujets d'inquiétudes\", suggéra Sabine. \"Même si cela ne mobilise que quelques stormtroopers. Nous ne sommes pas restés suffisamment longtemps sur Géonosis pour que je puisse m'en assurer, mais je pense que nous pourrions être capables de remettre en marche une partie de ces vieux droïdes de combat.\"\r\n\r\n\"Ou\", intervint Hera, \"nous pouvons essayer d'aider les rebelles Twi'lek sur Ryloth. L'Empire a intercepté leurs équipements depuis un moment maintenant. Si nous pouvons les aider à revenir dans la lutte, Thrawn aura une nouvelle épine dans le pied.\"\r\n\r\n{-} Les héros choisissent collectivement s'ils souhaitent inspecter l'usine de droïdes ou porter assistance aux rebelles Twi'lek.\r\n{-} Si les héros choisissent d'inspecter l'usine de droïdes, la prochaine mission active est \"État de siège sur Géonosis\".\r\n{-} Si les héros choisissent de porter assistance aux rebelles Twi'lek, la prochaine mission active est \"Course de vitesse sur Ryloth\".",
+      "eventActions": []
+    },
+    {
+      "eventName": "End of Round 5 Check",
+      "GUID": "7749a7e7-c54b-4581-af6d-197414ec927b",
+      "eventText": "",
+      "eventActions": []
+    },
+    {
+      "eventName": "AT-AT Activation uncaptured",
+      "GUID": "04bf8ddb-7b81-4456-8363-cc47e16423d5",
+      "eventText": "L'étage entier tangue alors que le TB-TT marche pesamment.\r\n\r\n{-} Activez le TB-TT Rebelle. Le TB-TT Rebelle ne peut pas attaquer. \r\n{-} Ensuite, chaque TB-TT Impérial résout les instructions suivantes, en commençant par le TB-TT le plus éloigné du TB-TT Rebelle :\r\n\r\n{A} Déplacement 1 vers le TB-TT Rebelle.\r\n{Q} Attaquer le TB-TT Rebelle.\r\n\r\n(Les TB-TT ont : Santé : 9, Défense : Aucune, Attaque : {O}, 1 dé bleu, Vitesse : 1.)",
+      "eventActions": []
+    },
+    {
+      "eventName": "AT-AT Activation captured",
+      "GUID": "7c682a51-7630-4c28-bc80-dcd3edc13169",
+      "eventText": "L'étage entier tangue alors que le TB-TT marche pesamment.\r\n\r\n{-} Activez les deux TB-TT Rebelles.\r\n{-} Au début de l'activation du TB-TT capturé, un héros sur ou adjacent à la direction (le terminal bleu) peut effectuer un test de {I} ou {J}. S'il réussit, le TB-TT capturé gagne 1 point de déplacement.\r\n{-} Au début de l'activation du TB-TT capturé, un héros sur ou adjacent à la console de tir (le terminal rouge) peut effectuer un test de {I} ou {K}. S'il réussit, le TB-TT capturé gagne 1 {h}.\r\n\r\n{-} Après l'activation des TB-TT Rebelles, le TB-TT Impérial résout les instructions suivantes :\r\n\r\n{A} Déplacement 1 vers le TB-TT Rebelle qui a subit le plus de {H}.\r\n{Q} Attaquer e TB-TT Rebelle qui a subit le plus de {H}.\r\n\r\n(Les TB-TT ont : Santé : 9, Défense : Aucune, Attaque : {O}, 1 dé bleu, Vitesse : 1.)",
+      "eventActions": []
+    },
+    {
+      "eventName": "Foresection entered",
+      "GUID": "8c7aa9d0-dd40-4965-910a-5dd6fdef2d8d",
+      "eventText": "Vous ouvrez la porte et vous retrouvez nez à nez avec d'autres troupes.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Mid Section Door",
+              "GUID": "a14ba52c-55bc-4f91-a7d4-288606234d24",
+              "theText": "Une solide porte permet de pénétrer plus profondément dans le TB-TT.",
+              "buttonList": [
+                {
+                  "GUID": "e7f6f50d-7d98-4af4-8e72-49cf5553b5a1",
+                  "theText": "{A} Ouvrir"
+                }
+              ]
+            }
+          ],
+          "GUID": "fc684a2b-ca11-4320-8b7e-31abed3a0026",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "Cockpit breached",
+      "GUID": "3c0b3db6-1f68-4701-b61e-3195b039e6cc",
+      "eventText": "Vous forcez la porte du cockpit et vous entrez en trombe.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Cockpit Door",
+              "GUID": "5641c490-1d75-4b2d-bc84-9e06e38c723f",
+              "theText": "Une solide porte permet d'accéder au cockpit du TB-TT.",
+              "buttonList": [
+                {
+                  "GUID": "340e019b-2935-4793-a750-af317a44995f",
+                  "theText": "{A} Ouvrir"
+                }
+              ]
+            },
+            {
+              "entityName": "DP Green 1",
+              "GUID": "62def6d7-5936-4853-a9f7-7efb7844a37c",
+              "theText": null,
+              "buttonList": []
+            }
+          ],
+          "GUID": "76a96fe2-f207-4d8a-90e5-7b66c4c9342c",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        },
+        {
+          "tbText": "Immédiatement, l'équipage du TB-TT se tourne vers vous.",
+          "GUID": "bef80eae-8e19-423a-ad89-e49cfac1e2dc",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "enemyName": null,
+          "customText": "",
+          "modification": null,
+          "repositionInstructions": "",
+          "GUID": "4fadfcb2-99f1-4005-ac1e-5352f381e01b",
+          "eventActionType": 6,
+          "eaName": "Deploy: DG006/Imperial Officer (Elite)"
+        },
+        {
+          "enemyName": null,
+          "customText": "",
+          "modification": null,
+          "repositionInstructions": "",
+          "GUID": "f6c2f7f8-472d-48c5-87f4-3d530557984d",
+          "eventActionType": 6,
+          "eaName": "Deploy: DG057/Death Trooper"
+        },
+        {
+          "enemyName": null,
+          "customText": "",
+          "modification": null,
+          "repositionInstructions": "",
+          "GUID": "2e251528-91d9-4b70-b60a-15ea8bf1d98f",
+          "eventActionType": 6,
+          "eaName": "Deploy: DG058/Death Trooper (Elite)"
+        },
+        {
+          "tbText": "Derrière les troupes, vous pouvez voir les commandes du marcheur, prêtes à être utilisées.",
+          "GUID": "51343bd9-c96c-4940-b738-a9864ae940cd",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Steering control",
+              "GUID": "1f0887b2-5200-489d-9b06-b20acf1cb977",
+              "theText": "La direction contrôle les mouvements du marcheur.\r\n\r\n{-} Un héros peut interagir avec l'un des deux terminaux pour prendre le contrôle du marcheur.",
+              "buttonList": [
+                {
+                  "GUID": "910a93e1-36ea-477f-a56e-a194015fb4cc",
+                  "theText": "{A} Prendre le contrôle"
+                }
+              ]
+            },
+            {
+              "entityName": "Fire control",
+              "GUID": "d82d5e00-4ae8-4db7-a918-31c10f467504",
+              "theText": "La console de tir coordonne les canons du marcheur.\r\n\r\n{-} Un héros peut interagir avec l'un des deux terminaux pour prendre le contrôle du marcheur.",
+              "buttonList": [
+                {
+                  "GUID": "203a5f2b-6d51-4c6e-be38-8feb0287ad91",
+                  "theText": "{A} Prendre le contrôle"
+                }
+              ]
+            }
+          ],
+          "GUID": "d816571e-6dea-4f54-8c67-244d6cb9d940",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        },
+        {
+          "tbText": "{-} Un héros peut interagir avec l'un des deux terminaux pour prendre le contrôle du marcheur.\r\n{-} La mission évolue quand un héros prend le contrôle du marcheur.",
+          "GUID": "c685b3db-0a4e-4f89-bd67-ca1dae20bb37",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "repositionText": "Bloquer l'accès aux terminaux.",
+          "GUID": "1c74da82-8392-425d-8a2e-6fd515d11532",
+          "eventActionType": 17,
+          "eaName": "Change Reposition Instructions"
+        },
+        {
+          "shortText": "Prendre le contrôle du marcheur.",
+          "longText": "",
+          "GUID": "2c515325-c97c-439d-945e-ec9f5e6e02ab",
+          "eventActionType": 2,
+          "eaName": "Change Objective"
+        },
+        {
+          "theText": "{-} Le Champ de bataille (cases d'extérieur) et tous les pions qui s'y trouvent ne peuvent pas être affectés par des effets de carte.\r\n{-} Le pion Mission Rebelle représente le TB-TT Rebelle.\r\n{-} Les pions Mission Impériaux représentent les TB-TT Impériaux.\r\n{-} Les TB-TT ont : Santé : 9, Défense : Aucune, Attaque : {O}, 1 dé bleu, Vitesse : 1.\r\n{-} Les Pions Missions Rebelles sont des figurines Rebelles et les pions Missions Impériaux sont des figurines Impériales.\r\n{-} Les TB-TT Rebelles ne peuvent pas attaquer. \r\n{-} Les TB-TT ne s'activent pas normalement. À la place, à la fin de la phase d'activation, chaque TB-TT Rebelle s'active. Ensuite, chaque TB-TT Impérial s'active.\r\n{-} Un héros peut interagir avec l'un des deux terminaux pour prendre le contrôle du marcheur.\r\n{-} La mission évolue quand un héros prend le contrôle du marcheur.\r\n{-} Quand un TB-TT Rebelle est vaincu, cliquez sur la case en surbrillance du Champ de bataille (cases d'extérieur) et sélectionnez \"TB-TT Rebelle vaincu\".\r\n{-} Les Rebelles perdent quand un TB-TT Rebelle est vaincu, ou quand tous les héros sont blessés.",
+          "GUID": "7242278f-a3db-4b86-aed1-240a23de8058",
+          "eventActionType": 1,
+          "eaName": "Change Mission Info"
+        }
+      ]
+    },
+    {
+      "eventName": "Commandeered",
+      "GUID": "879d40c3-00b8-4e8c-9322-29c6f4cea4a4",
+      "eventText": "Vous prenez le contrôle aux Impériaux et vous asseyez dans le siège du pilote. \"Bien joué !\", crie Wolffe dans le com. \"Maintenant, on va les affronter, ok ?\" À l'extérieur, vous pouvez voir le TB-TT de Wolffe se diriger lentement vers ses anciens poursuivants. La chasse est ouverte.\r\n\r\n{-} Les héros choisissent un TB-TT Impérial et retournent son pion du côté Rebelle. Ce TB-TT est le TB-TT capturé.\r\n{-} Les TB-TT Rebelles peuvent maintenant attaquer.",
+      "eventActions": [
+        {
+          "tbText": "{-} Au début de l'activation du TB-TT capturé, un héros sur ou adjacent à la direction (le terminal bleu) peut effectuer un test de {I} ou {J}. S'il réussit, le TB-TT capturé gagne 1 point de déplacement.\r\n{-} Au début de l'activation du TB-TT capturé, un héros sur ou adjacent à la console de tir (le terminal rouge) peut effectuer un test de {I} ou {K}. S'il réussit, le TB-TT capturé gagne 1 {h}.\r\n{-} Quand un TB-TT Rebelle est vaincu, cliquez sur la case en surbrillance du Champ de bataille (cases d'extérieur) et sélectionnez \"TB-TT Rebelle vaincu\". Quand un TB-TT Impérial est vaincu, cliquez sur la case en surbrillance du Champ de bataille (cases d'extérieur) et sélectionnez \"TB-TT Impérial vaincu\".\r\n{-} Les Rebelles gagnent quand le TB-TT Impérial est vaincu.",
+          "GUID": "ee1695c3-fc5d-4133-b4a6-0e7dd8b8d70b",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "AT-AT Highlight",
+              "GUID": "2589a7a7-dd4a-49cb-9246-f50c14881960",
+              "theText": "Quand un TB-TT Rebelle est vaincu, cliquez sur \"TB-TT Rebelle vaincu\". Quand un TB-TT Impérial est vaincu, cliquez sur \"TB-TT Impérial vaincu\".",
+              "buttonList": [
+                {
+                  "GUID": "5c211d4c-0920-4267-9ff5-f2f1327d5474",
+                  "theText": "TB-TT Rebelle vaincu"
+                },
+                {
+                  "GUID": "80a35c4d-9540-4d41-9a3c-8d443269c1d1",
+                  "theText": "TB-TT Impérial vaincu"
+                }
+              ]
+            },
+            {
+              "entityName": "Steering control",
+              "GUID": "2c8b0d4d-abce-4597-8bd2-db3b77fdafb7",
+              "theText": "La direction contrôle les mouvements du marcheur.\r\n\r\n{-} Au début de l'activation du TB-TT capturé, un héros sur ou adjacent à la direction peut effectuer un test de {I} ou {J}. S'il réussit, le TB-TT capturé gagne 1 point de déplacement.",
+              "buttonList": []
+            },
+            {
+              "entityName": "Fire control",
+              "GUID": "af42b04a-a517-4d9d-aaff-3fa319020957",
+              "theText": "La console de tir coordonne les canons du marcheur.\r\n\r\n{-} Au début de l'activation du TB-TT capturé, un héros sur ou adjacent à la console de tir peut effectuer un test de {I} ou {K}. S'il réussit, le TB-TT capturé gagne 1 {h}.",
+              "buttonList": []
+            }
+          ],
+          "GUID": "b827f5a8-ee8c-425d-a562-e5462612f6c7",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        },
+        {
+          "repositionText": null,
+          "GUID": "ebb2b006-8de0-46c9-bb4c-3d73f2fe0922",
+          "eventActionType": 17,
+          "eaName": "Change Reposition Instructions"
+        },
+        {
+          "shortText": "Détruire le TB-TT Impérial.",
+          "longText": null,
+          "GUID": "8e242316-4d7a-460a-bb73-e4909ff92f86",
+          "eventActionType": 2,
+          "eaName": "Change Objective"
+        },
+        {
+          "theText": "{-} Le Champ de bataille (cases d'extérieur) et tous les pions qui s'y trouvent ne peuvent pas être affectés par des effets de carte.\r\n{-} Les pions Mission Rebelles représentent les TB-TT Rebelles.\r\n{-} Le pion Mission Impérial représente le TB-TT Impérial.\r\n{-} Les TB-TT ont : Santé : 9, Défense : Aucune, Attaque : {O}, 1 dé bleu, Vitesse : 1.\r\n{-} Les Pions Missions Rebelles sont des figurines Rebelles et les pions Missions Impériaux sont des figurines Impériales.\r\n{-} Les TB-TT ne s'activent pas normalement. À la place, à la fin de la phase d'activation, chaque TB-TT Rebelle s'active. Ensuite, chaque TB-TT Impérial s'active.\r\n{-} Au début de l'activation du TB-TT capturé, un héros sur ou adjacent à la direction (le terminal bleu) peut effectuer un test de {I} ou {J}. S'il réussit, le TB-TT capturé gagne 1 point de déplacement.\r\n{-} Au début de l'activation du TB-TT capturé, un héros sur ou adjacent à la console de tir (le terminal rouge) peut effectuer un test de {I} ou {K}. S'il réussit, le TB-TT capturé gagne 1 {h}.\r\n{-} Quand un TB-TT Rebelle est vaincu, cliquez sur la case en surbrillance du Champ de bataille (cases d'extérieur) et sélectionnez \"TB-TT Rebelle vaincu\". Quand un TB-TT Impérial est vaincu, cliquez sur la case en surbrillance du Champ de bataille (cases d'extérieur) et sélectionnez \"TB-TT Impérial vaincu\".\r\n{-} Les Rebelles gagnent quand le TB-TT Impérial est vaincu.\r\n{-} Les Rebelles perdent quand un TB-TT Rebelle est vaincu, ou quand tous les héros sont blessés.",
+          "GUID": "414300af-efb1-4768-bf57-1f36b58f7773",
+          "eventActionType": 1,
+          "eaName": "Change Mission Info"
+        }
+      ]
+    },
+    {
+      "eventName": "Intruder Alert",
+      "GUID": "f6257004-674b-4d10-a96e-5845329276e0",
+      "eventText": "D'autres troupes se précipitent pour vous empêcher de réquisitionner le TB-TT.",
+      "eventActions": []
+    },
+    {
+      "eventName": "CT present",
+      "GUID": "40cbb412-440f-413e-ba4b-bb41322b1182",
+      "eventText": "",
+      "eventActions": []
+    },
+    {
+      "eventName": "Mission Ends Win CT Yes",
+      "GUID": "6f0e8c86-a5bf-4a45-82b4-ae3a3150ccda",
+      "eventText": "CT-1701 reçoit la carte Récompense \"Dans le mille !\".",
+      "eventActions": []
+    },
+    {
+      "eventName": "Mission Ends Win CT No",
+      "GUID": "957b5cb0-c62e-4150-a055-eaac45a0a0b9",
+      "eventText": "Les héros reçoivent 150 crédits par héros.",
+      "eventActions": []
+    },
+    {
+      "eventName": "Mission Ends Defeat",
+      "GUID": "f6f8d62f-7f6a-4e16-bdf4-d960a7b071dd",
+      "eventText": "",
+      "eventActions": []
+    },
+    {
+      "eventName": "End of Round 5",
+      "GUID": "78a68094-fadf-4982-ac61-b80c37a2d0eb",
+      "eventText": "",
+      "eventActions": []
+    }
+  ],
+  "mapEntities": [
+    {
+      "entityName": "Crate1",
+      "GUID": "dcf1e03e-e328-4f79-8427-e0a0bfc64f82",
+      "mainText": "Une vieille caisse de ravitaillement.",
+      "buttonList": [
+        {
+          "GUID": "d2a79f3a-92a4-425b-b448-0681c02e1e09",
+          "theText": "{A} Ouvrir"
+        }
+      ]
+    },
+    {
+      "entityName": "Crate2",
+      "GUID": "461e69e0-7c26-42a1-ad2a-a5e71b4f7707",
+      "mainText": "Une vieille caisse de ravitaillement.",
+      "buttonList": [
+        {
+          "GUID": "0450f260-11e1-41b0-8a47-670bc8a8398c",
+          "theText": "{A} Ouvrir"
+        }
+      ]
+    },
+    {
+      "entityName": "Crate3",
+      "GUID": "1e60bee2-7e72-4f71-8c0e-45b5a2d0baf8",
+      "mainText": "Une vieille caisse de ravitaillement.",
+      "buttonList": [
+        {
+          "GUID": "7781bca0-22cb-47a3-bd38-7d36cbb11d5c",
+          "theText": "{A} Ouvrir"
+        }
+      ]
+    },
+    {
+      "entityName": "Entrance",
+      "GUID": "a343a128-3b10-48ff-878f-71c89176d776",
+      "mainText": "Déployer les héros ici.",
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Green 1",
+      "GUID": "c8062d94-a52f-4458-b2cf-3c7b515747e5",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Green 2",
+      "GUID": "5bdffef2-c7c7-4e16-ab66-dca82b0481fd",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Trooper 1",
+      "GUID": "81ead058-7663-414c-aed5-13a096cc71f9",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "Rebel AT-AT",
+      "GUID": "e9c1cbbf-fb11-4e9c-bdc9-391c5e21377b",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "Imperial AT-AT 1",
+      "GUID": "3bcdb08b-a233-46ff-86fd-236485efb6ef",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "Imperial AT-AT 2",
+      "GUID": "d8bffe12-afdf-4659-8240-2b86c43d0660",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "AT-AT Highlight",
+      "GUID": "c44a77fb-4a32-4735-a075-af4c9ecbcb0d",
+      "mainText": "Quand un TB-TT Rebelle est vaincu, cliquez sur \"TB-TT Rebelle vaincu\".",
+      "buttonList": [
+        {
+          "GUID": "0a4ede49-101d-4227-846d-f5992b8a1848",
+          "theText": "TB-TT Rebelle vaincu"
+        }
+      ]
+    },
+    {
+      "entityName": "DP Trooper 2",
+      "GUID": "659ddee3-c15a-48b4-a659-28bd8321016d",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Trooper 3",
+      "GUID": "2829eb95-8709-4d2c-968b-37ee60e1e579",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Officer",
+      "GUID": "6257c339-ff9e-4093-ae3d-597be1873adf",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "Mid Section Door",
+      "GUID": "466bc0cd-7b86-4a75-8848-50888f3d1f23",
+      "mainText": "Une solide porte permet de pénétrer plus profondément dans le TB-TT.",
+      "buttonList": [
+        {
+          "GUID": "ff4ff200-f142-4829-83cb-01e0dd416999",
+          "theText": "{A} Ouvrir"
+        }
+      ]
+    },
+    {
+      "entityName": "Cockpit Door",
+      "GUID": "c062a2fd-f6af-4100-b717-58fe76f63b47",
+      "mainText": "Une solide porte permet d'accéder au cockpit du TB-TT.",
+      "buttonList": [
+        {
+          "GUID": "1f464408-580d-400f-a4d2-09e811e1ad64",
+          "theText": "{A} Ouvrir"
+        }
+      ]
+    },
+    {
+      "entityName": "DP Red 1",
+      "GUID": "bc73ffeb-be9c-4854-b372-1d161e13630f",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Red 2",
+      "GUID": "0575ba7c-00e8-48f3-9da6-dbe3c1dc666d",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "Steering control",
+      "GUID": "3d230cce-bc92-4b85-bc13-eedca8f46692",
+      "mainText": "La direction contrôle les mouvements du marcheur.\r\n\r\n{-} Un héros peut interagir avec l'un des deux terminaux pour prendre le contrôle du marcheur.",
+      "buttonList": [
+        {
+          "GUID": "2341e326-c3d6-445a-949a-4007a617eb4c",
+          "theText": "{A} Prendre le contrôle"
+        }
+      ]
+    },
+    {
+      "entityName": "Fire control",
+      "GUID": "282ba109-02fb-4d00-8bb8-14b382bd3864",
+      "mainText": "La console de tir coordonne les canons du marcheur.\r\n\r\n{-} Un héros peut interagir avec l'un des deux terminaux pour prendre le contrôle du marcheur.",
+      "buttonList": [
+        {
+          "GUID": "355a68ed-67a8-411c-a6c9-8988dafa4861",
+          "theText": "{A} Prendre le contrôle"
+        }
+      ]
+    },
+    {
+      "entityName": "DP DTrooper",
+      "GUID": "8c01f03c-8e3b-4b28-9424-174a7b3789f4",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Cockpit Red",
+      "GUID": "d07e3f74-e71e-424d-a836-5c1e587b1627",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Cockpit Blue",
+      "GUID": "07401005-142e-403a-8271-a557ff97b877",
+      "mainText": null,
+      "buttonList": []
+    }
+  ],
+  "initialGroups": []
+}

--- a/ImperialCommander2/Assets/Resources/Languages/Fr/Missions/Lothal/LOTHAL5_FR.json
+++ b/ImperialCommander2/Assets/Resources/Languages/Fr/Missions/Lothal/LOTHAL5_FR.json
@@ -1,0 +1,1122 @@
+{
+  "languageID": "French (FR)",
+  "missionProperties": {
+    "missionName": "État de siège sur Géonosis",
+    "missionDescription": "Si vous jouez une mini-campagne, les héros doivent emmener un allié Spectre qu'ils n'ont pas déjà emmené lors d'une mission de cette mini-campagne. ==== Grâce aux missions de reconnaissance que les Spectres ont effectuées sur Géonosis, la Rébellion caresse l'opportunité de récupérer une ancienne usine de droïdes de combat sur cette planète afin d'utiliser ces soldats datant de la Guerre des Clones contre les forces de l'Empire. Un membre des Spectres vous rejoindra sur le site.",
+    "missionInfo": "",
+    "campaignName": "Tyrans de Lothal",
+    "startingObjective": "",
+    "repositionOverride": "Bloquer l'accès aux terminaux.",
+    "additionalMissionInfo": "Si vous jouez une mini-campagne, les héros doivent emmener un allié Spectre qu'ils n'ont pas déjà emmené lors d'une mission de cette mini-campagne."
+  },
+  "events": [
+    {
+      "eventName": "Open Crate 1",
+      "GUID": "2dec36b9-ce77-4bf6-8c35-9489e6573609",
+      "eventText": "Vous fouillez la caisse et prenez ce qui vous semble utile.\r\n\r\nPiochez une carte Ravitaillement. Vous gagnez 1 médipack. Récupérez ce pion.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Crate1",
+              "GUID": "690ee74e-8fe6-4440-aa0b-0e98af05fba1",
+              "theText": "Une vieille caisse de ravitaillement.",
+              "buttonList": [
+                {
+                  "GUID": "b968560b-6b4e-4fc6-a1f6-b7df0afec481",
+                  "theText": "{A} Ouvrir"
+                }
+              ]
+            }
+          ],
+          "GUID": "8eb6c4bb-fd64-4ae8-9b6d-a5ba3f737e6a",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "Open Crate 2",
+      "GUID": "74bbaee9-47db-48c2-b09c-7d0940adf6ab",
+      "eventText": "Vous fouillez la caisse et prenez ce qui vous semble utile.\r\n\r\nPiochez une carte Ravitaillement. Vous gagnez 1 médipack. Récupérez ce pion.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Crate2",
+              "GUID": "0295aecd-863a-45ae-85b0-112166dfd462",
+              "theText": "Une vieille caisse de ravitaillement.",
+              "buttonList": []
+            }
+          ],
+          "GUID": "a6f06d59-b18c-465a-acc1-85db4a122e25",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "Open Crate 3",
+      "GUID": "4c60aea9-45d0-4dbe-9bea-27d51eba9079",
+      "eventText": "Vous fouillez la caisse et prenez ce qui vous semble utile.\r\n\r\nPiochez une carte Ravitaillement. Vous gagnez 1 médipack. Récupérez ce pion.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Crate3",
+              "GUID": "2b55d7e7-f842-4792-b345-07708ba817c2",
+              "theText": "Une vieille caisse de ravitaillement.",
+              "buttonList": []
+            }
+          ],
+          "GUID": "50b5bf42-216f-45db-925e-d733f34fdd76",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "Mission Briefing",
+      "GUID": "edc56ae0-7e4f-4ecd-9176-26e69bfd835a",
+      "eventText": "Vous terminez de fouiller de fond en comble l'usine désaffectée lorsque la voix de votre pilote résonne sur votre comlink. \"Les Impériaux se dirigent dans votre direction ! J'arrive pour vous prendre aux coordonnées du rendez-vous.\" Tout à coup, vous entendez que les systèmes de sécurité de l'usine reviennent à la vie. De lourdes portes se referment au loin.\r\n\r\n{-} Déployez les héros sur la case bleue en surbrillance.\r\n{-} La porte est verrouillée.\r\n{-} Quand un héros se replie, il est neutralisé à la place. Quand il est activé, il ne reçoit que 1 action et ne peut utiliser cette action que pour effectuer un déplacement.",
+      "eventActions": [
+        {
+          "tbText": "Les portes sont contrôlées par un trio de terminaux de sécurité disséminés dans l'usine.",
+          "GUID": "c5cc94af-87ce-4021-a655-59b4b4a698fe",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Terminal Red",
+              "GUID": "51caf464-4980-42a8-8cba-82b64e9ecd1d",
+              "theText": "Un des terminaux contrôlant le système de sécurité de l'usine.\r\n\r\n{-} Une figurine Rebelle peut interagir avec un terminal ({I} ou {J}). Si elle réussit, cette figurine s'approprie le terminal. Sinon, défaussez ce terminal.",
+              "buttonList": [
+                {
+                  "GUID": "57326e4f-1383-4cdc-83c5-d8146c6aa941",
+                  "theText": "{A} Pirater"
+                }
+              ]
+            },
+            {
+              "entityName": "Terminal Blue",
+              "GUID": "32087dcd-705a-46d8-bc8e-37a3f3f58ada",
+              "theText": "Un des terminaux contrôlant le système de sécurité de l'usine.\r\n\r\n{-} Une figurine Rebelle peut interagir avec un terminal ({I} ou {J}). Si elle réussit, cette figurine s'approprie le terminal. Sinon, défaussez ce terminal.",
+              "buttonList": [
+                {
+                  "GUID": "5e22ef38-5180-43e0-8357-d915d5c793c0",
+                  "theText": "{A} Pirater"
+                }
+              ]
+            },
+            {
+              "entityName": "Terminal Green",
+              "GUID": "db6af407-473d-43a9-a5b2-3e7df20790ef",
+              "theText": "Un des terminaux contrôlant le système de sécurité de l'usine.\r\n\r\n{-} Une figurine Rebelle peut interagir avec un terminal ({I} ou {J}). Si elle réussit, cette figurine s'approprie le terminal. Sinon, défaussez ce terminal.",
+              "buttonList": [
+                {
+                  "GUID": "043b76dc-e245-4997-85f7-6cc97b502daa",
+                  "theText": "{A} Pirater"
+                }
+              ]
+            }
+          ],
+          "GUID": "d4ec1032-25e0-4bcc-9384-c8663925711d",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        },
+        {
+          "tbText": "{-} Une figurine Rebelle peut interagir avec un terminal ({I} ou {J}). Si elle réussit, cette figurine s'approprie le terminal. Sinon, défaussez ce terminal.\r\n{-} La porte s'ouvre quand tous les terminaux ont été appropriés ou défaussés.",
+          "GUID": "f352a481-1c7d-4117-a2e9-10cd136ac284",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "tbText": "Plusieurs vieux droïdes de combat délabrés se tiennent à proximité, n'ayant pas bougé depuis des années.",
+          "GUID": "d112c876-d55c-40e7-8fe6-f353cde236dd",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Battle Droid Red",
+              "GUID": "48a9ff41-be33-460d-839e-92f2d4f3c69a",
+              "theText": "Le vieux droïde de combat délabré est recouvert d'une fine couche de poussière.",
+              "buttonList": []
+            },
+            {
+              "entityName": "Battle Droid Blue",
+              "GUID": "af9ef477-67c1-4969-839a-c144d2005f79",
+              "theText": "Le vieux droïde de combat délabré est recouvert d'une fine couche de poussière.",
+              "buttonList": []
+            },
+            {
+              "entityName": "Battle Droid Green",
+              "GUID": "359a2bd2-9ef5-4505-9a23-f1926ff93c3c",
+              "theText": "Le vieux droïde de combat délabré est recouvert d'une fine couche de poussière.",
+              "buttonList": []
+            }
+          ],
+          "GUID": "9e9dfa22-313a-4eda-8a56-2bcd4d09ba80",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        },
+        {
+          "tbText": "{-} Les pions Mission neutres représentent des droïdes de combat désactivés.",
+          "GUID": "4fd9c2bd-036f-4c8a-9d19-7305dc598e40",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "tbText": "Vous sortez vos armes, prêts à vous battre pour sortir.\r\n\r\n{-} La mission évolue quand tous les terminaux ont été appropriés ou défaussés.\r\n{-} Les Rebelles perdent si tous les héros ne sont pas sur la Zone d'Extraction à la fin du Round 6, ou quand tous les héros sont blessés. (Si la limite de Rounds est désactivée, les héros peuvent quitter les lieux pendant des Rounds ultérieurs.)",
+          "GUID": "fae2cb60-462a-452a-be8d-6c879b2173ea",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "shortText": "Désactiver les terminaux de sécurité (&Terminals gone&/3).",
+          "longText": null,
+          "GUID": "2744e659-6535-4ec9-a303-a8c19e9f9af8",
+          "eventActionType": 2,
+          "eaName": "Change Objective"
+        },
+        {
+          "theText": "{-} La porte est verrouillée. Elle s'ouvre quand tous les terminaux ont été appropriés ou défaussés.\r\n{-} Une figurine Rebelle peut interagir avec un terminal ({I} ou {J}). Si elle réussit, cette figurine s'approprie le terminal. Sinon, défaussez ce terminal.\r\n{-} Quand un héros se replie, il est neutralisé à la place. Quand il est activé, il ne reçoit que 1 action et ne peut utiliser cette action que pour effectuer un déplacement.\r\n{-} La mission évolue quand tous les terminaux ont été appropriés ou défaussés.\r\n{-} Les Rebelles perdent si tous les héros ne sont pas sur la Zone d'Extraction à la fin du Round 6, ou quand tous les héros sont blessés. (Si la limite de Rounds est désactivée, les héros peuvent quitter les lieux pendant des Rounds ultérieurs.)",
+          "GUID": "18a7c09c-c540-480b-8bf0-1afc0ac988d5",
+          "eventActionType": 1,
+          "eaName": "Change Mission Info"
+        }
+      ]
+    },
+    {
+      "eventName": "End of Mission - Rebels win",
+      "GUID": "69b80fad-5e0e-46cd-a70e-defa45de4db6",
+      "eventText": "\"Prête à partir ! Si vous ne montez pas, je pars sans vous !\" crie votre pilote pour se faire entendre malgré le vacarme des moteurs de votre vaisseau. Vous vous précipitez à bord en conservant près de vous le matériel que vous avez récupéré.\r\n\r\n{-} Les Rebelles remportent la mission !\r\n{-} Si vous jouez cette mission en tant que mission annexe, les héros reçoivent 1 allié Spectre de leur choix en tant qu'allié.",
+      "eventActions": [
+        {
+          "mainText": "Jouez-vous cette mission dans le cadre de la mini-campagne \"Tyrans de Lothal\" ?",
+          "buttonList": [
+            {
+              "GUID": "bf1589df-af5f-4da8-ae6a-c2e581872596",
+              "theText": "Oui"
+            },
+            {
+              "GUID": "6ead200f-5bb8-49be-b951-a8870b7d2beb",
+              "theText": "Non"
+            }
+          ],
+          "GUID": "fa160c96-ff1c-4306-ad5f-f40d51ef9331",
+          "eventActionType": 5,
+          "eaName": "Question Prompt"
+        }
+      ]
+    },
+    {
+      "eventName": "End of Mission - Rebels lose",
+      "GUID": "9e960fce-d271-468c-8d6c-233bc752aa52",
+      "eventText": "Vous vous échappez de justesse, en sautant dans le déversoir à ordures de l'usine, qui vous rejette dans la friche environnante. Heureusement, une autre navette ne va pas tarder à vous récupérer !\r\n\r\n{-} Les Rebelles perdent la mission.",
+      "eventActions": [
+        {
+          "mainText": "Jouez-vous cette mission dans le cadre de la mini-campagne \"Tyrans de Lothal\" ?",
+          "buttonList": [
+            {
+              "GUID": "03aeedef-f8f4-43a3-ba72-40e890468195",
+              "theText": "Oui"
+            },
+            {
+              "GUID": "3ff45b14-53ae-46ec-a2d2-c377653e70dc",
+              "theText": "Non"
+            }
+          ],
+          "GUID": "922d0b18-3b9c-4426-b8b1-9d79afd7d873",
+          "eventActionType": 5,
+          "eaName": "Question Prompt"
+        }
+      ]
+    },
+    {
+      "eventName": "Mini campaign Win",
+      "GUID": "1fb0c0b1-7388-42f6-9c4c-801de27f03a5",
+      "eventText": "Votre vaisseau s'envole en trombe tandis que des soldats Impériaux l'arrosent de tirs de fusils blaster. En dessous de vous, vous voyez des stormtroopers aux prises avec des droïdes de combat. L'Empire devra dépenser beaucoup d'énergie pour tous les déloger. C'est autant de ressources qu'ils ne pourront pas mobiliser contre la Rébellion.\r\n\r\nVous rencontrez le Ghost quelques jours plus tard. \"L'Empire a envoyé de nouvelles troupes pour faire mordre la poussière aux droïdes\", vous informe Sabine. \"Mieux vaut eux que nous.\"\r\n\r\n{-} Chaque héros reçoit 3 XP.\r\n{-} Les héros reçoivent 300 crédits par héros.\r\n{-} Les joueurs Rebelles choisissent 1 héros qui reçoit la carte Récompense \"Expert en technologie\".",
+      "eventActions": [
+        {
+          "mainText": "Veuillez sélectionner la bonne option :\r\n\r\n{-} Campagne étendue : vous jouez la mini-campagne étendue avec l'extension de figurine \"Thrawn\".\r\n{-} Mini-campagne : vous jouez la mini-campagne \"Tyrans de Lothal\" sans l'extension de figurine.",
+          "buttonList": [
+            {
+              "GUID": "cd027f91-6829-4a22-a20b-823190a1f50a",
+              "theText": "Campagne étendue"
+            },
+            {
+              "GUID": "cfe771a5-3494-4617-a136-f44e88276686",
+              "theText": "Mini-campagne"
+            }
+          ],
+          "GUID": "d93f8f65-094a-440f-bd2c-2849d9099137",
+          "eventActionType": 5,
+          "eaName": "Question Prompt"
+        }
+      ]
+    },
+    {
+      "eventName": "Mini campaign Defeat",
+      "GUID": "ee9e6f21-9b9f-47ca-b982-44b59453a837",
+      "eventText": "Vous voyez votre vaisseau filer en orbite, poursuivi par un duo de chasseurs TIE tandis que vous vous faufilez au milieu des rochers escarpés du paysage Géonosien. Des stormtroopers submergent la zone. Avant le crépuscule, vous avez trouvé refuge dans les ruines d'un croiseur de combat de la Fédération du Commerce pour vous préserver de la nuit froide.\r\n\r\nVotre vaisseau est de retour au matin. Lors du rendez-vous suivant, vous présentez toujours des mines renfrognées. \"On dirait que vous vous êtes retrouvés du mauvais côté d'un nid de krykna\", commente Zeb.\r\n\r\n{-} Chaque héros reçoit 3 XP.\r\n{-} Les héros reçoivent 300 crédits par héros.",
+      "eventActions": [
+        {
+          "mainText": "Veuillez sélectionner la bonne option :\r\n\r\n{-} Campagne étendue : vous jouez la mini-campagne étendue avec l'extension de figurine \"Thrawn\".\r\n{-} Mini-campagne : vous jouez la mini-campagne \"Tyrans de Lothal\" sans l'extension de figurine.",
+          "buttonList": [
+            {
+              "GUID": "62a73213-a880-4536-ba95-fd775ab5594a",
+              "theText": "Campagne étendue"
+            },
+            {
+              "GUID": "51d1d978-9018-4646-bf6a-60f32b0b7047",
+              "theText": "Mini-campagne"
+            }
+          ],
+          "GUID": "c47a75a7-d9d7-4f27-ab49-39ee814934b8",
+          "eventActionType": 5,
+          "eaName": "Question Prompt"
+        }
+      ]
+    },
+    {
+      "eventName": "No campaign",
+      "GUID": "8fe1b24a-487b-46a0-9e81-94329508e0dc",
+      "eventText": "{-} Chaque héros reçoit 1 XP.\r\n{-} Les héros reçoivent 100 crédits par héros.",
+      "eventActions": []
+    },
+    {
+      "eventName": "Extended campaign 1",
+      "GUID": "2f95d44b-fe49-4580-aed5-8b4db04f67d8",
+      "eventText": "Thrawn vous suit à la trace depuis que vous avez rejoint les Spectres. Vous êtes certains de ne pas avoir révélé les coordonnées de ces derniers, mais cela commence à devenir un véritable problème. Le genre qu'il vous faudra résoudre si vous voulez garder une longueur d'avance sur Thrawn.\r\n\r\nN-4M, votre contact sur Lothal, vous apporte de bonnes nouvelles. \"J'ai fait l'acquisition de quelques codes d'accès Impériaux\", vous informe le droïde. \"Je pense qu'ils vous donneront accès à un lieu bien précis : la baie d'amarrage secondaire du destroyer stellaire Chimaera.\" N-4M n'a pas besoin d'expliquer en quoi ces informations peuvent être utiles. Les droïdes d'infiltration de Thrawn sont contrôlés depuis ce vaisseau amiral. Une frappe chirurgicale au cœur de l'appareil pourrait vous permettre de respirer un peu.\r\n\r\n{-} La prochaine mission active est \"La poigne de l'amiral\" (extension de figurine antagoniste Thrawn).",
+      "eventActions": []
+    },
+    {
+      "eventName": "Regular mini campaign",
+      "GUID": "5912594d-6f76-449a-8572-5004d336bdd9",
+      "eventText": "Un débat fait rage dans la salle commune du Ghost et vous l'entendez bien avant de le voir. \"Cela pourrait être notre meilleure chance de porter le combat sur le terrain de Thrawn\", insista Ezra tandis qu'il montrait une représentation holographique de Lothal et des nombreux destroyers stellaires qui gravitaient sur son orbite. \"Je sais que cela pourrait être un piège, mais si ce n'en était pas un ? Nous avons travaillé dur pour trouver une brèche qui nous permettrait de répondre aux attaques de Thrawn.\"\r\n\r\nVous les interrompez pour connaître l'objet de leur dispute.\r\n\r\n\"Un ingénieur Impérial nous a envoyé un message\", répond Kanan. \"Il veut déserter, et il prétend pouvoir nous introduire dans la chambre des données qui contient toutes les informations collectées par les droïdes d'infiltration de Thrawn.\" Lorsque le masque de Kanan se tourne dans votre direction, vous ne pouvez qu'imaginer son regard lourd de sens. \"Ces données lui donnent un avantage sur la Rébellion. Mais croire que quelqu'un nous laissera rentrer ? Cela semble trop beau pour être vrai.\"\r\n\r\n\"Nous n'aurons même pas l'occasion d'atterrir avec les gorilles de Thrawn partout dans les parages\", commente Zeb. \"Tous les Impériaux du secteur savent probablement à quoi nous ressemblons.\"\r\n\r\nVous faites un pas en avant. Les Spectres sont une pièce maîtresse de la Rébellion. Ils ne peuvent pas se permettre de prendre un tel risque. Mais vous, vous le pouvez.\r\n\r\n{-} La prochaine mission active est \"L'ordre final\".",
+      "eventActions": []
+    },
+    {
+      "eventName": "TRed Attempt",
+      "GUID": "42cc502a-4921-4b1e-a5fa-8bce0393edf1",
+      "eventText": "",
+      "eventActions": [
+        {
+          "mainText": "Vous commencez à pirater le terminal.\r\n\r\nEffectuez un test {J} ou {I}. Appliquez +1 {B} au test pour chaque pion Stress présent sur le terminal, puis défaussez ces pions Stress. Entrez le nombre de réussites ci-dessous.",
+          "failText": "",
+          "inputList": [
+            {
+              "GUID": "126f16c1-0678-4baa-9117-1a06d562da50",
+              "theText": ""
+            },
+            {
+              "GUID": "750afebd-8a74-4943-9ea5-776f54b7a4bd",
+              "theText": null
+            }
+          ],
+          "GUID": "ca1691b9-2507-4860-91cf-e7bf4e417e80",
+          "eventActionType": 20,
+          "eaName": "Input Prompt"
+        }
+      ]
+    },
+    {
+      "eventName": "TRed Discard",
+      "GUID": "62b73056-3f9c-4523-89fa-360582c13f2a",
+      "eventText": "Vous ne parvenez pas à pirater le terminal, vous décidez donc de le détruire pour déverrouiller la porte.\r\n\r\n{-} Défaussez le terminal.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Terminal Red",
+              "GUID": "49a71da3-aa18-473f-a3f9-859f295af37e",
+              "theText": "Un des terminaux contrôlant le système de sécurité de l'usine.\r\n\r\n{-} Une figurine Rebelle peut interagir avec un terminal ({I} ou {J}). Si elle réussit, cette figurine s'approprie le terminal. Sinon, défaussez ce terminal.",
+              "buttonList": [
+                {
+                  "GUID": "cb406b53-4cb7-4263-b5c1-7c4a3f4012e2",
+                  "theText": "{A} Pirater"
+                }
+              ]
+            }
+          ],
+          "GUID": "a508b5f1-8736-4f74-b06a-5819ec1e904a",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        },
+        {
+          "tbText": "Maintenant que le terminal n'est plus là, un des vieux droïdes de combat est vraiment devenu inutile.\r\n\r\n{-} Défaussez le droïde de combat rouge.",
+          "GUID": "2e0de87a-d73d-48b4-b298-5b475d051bd0",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Battle Droid Red",
+              "GUID": "8cb1b6f3-4ce5-488b-ba4c-9755f3fbb873",
+              "theText": "Le vieux droïde de combat délabré est recouvert d'une fine couche de poussière.",
+              "buttonList": []
+            }
+          ],
+          "GUID": "472097e4-74f2-4e71-b589-123d805cb063",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "TRed Claim",
+      "GUID": "4235bef4-83e9-4154-b980-357c9de60019",
+      "eventText": "Vous parvenez à pirater le terminal. Vous en prenez le contrôle et désactivez une partie de la serrure.\r\n\r\n{-} Vous vous appropriez le terminal.",
+      "eventActions": [
+        {
+          "tbText": "Non loin de vous, un droïde de combat en léthargie depuis des dizaines d'années bourdonne et reprend vie. Il porte un fusil blaster rouillé et pose les yeux sur vous.\r\n\r\n{-} Une fois durant son activation, un héros peut commander le droïde de combat rouge. Ce héros peut pousser le droïde de combat jusqu'à 3 cases. Ensuite, il peut choisir une figurine à 3 cases ou moins du droïde de combat dans sa ligne de vue. Lancez 1 dé bleu. Cette figurine subit autant de {H} que de {H} obtenus. Chaque droïde de combat peut être commandé une fois par round.",
+          "GUID": "85301eeb-d5c1-4d56-b6e3-2b9c966686aa",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "GUID": "6dfc24b6-ceb6-405e-af35-489245df753a",
+          "eventActionType": 21,
+          "eaName": "Custom Deployment: Red Battle Droid",
+          "repositionInstructions": "",
+          "surges": "",
+          "bonuses": "",
+          "keywords": "",
+          "abilities": "DROÏDE DE COMBAT : Une fois durant son activation, un héros peut commander le droïde de combat rouge. Ce héros peut pousser le droïde de combat jusqu'à 3 cases. Ensuite, il peut choisir une figurine à 3 cases ou moins du droïde de combat dans sa ligne de vue. Lancez 1 dé bleu. Cette figurine subit autant de {H} que de {H} obtenus. Chaque droïde de combat peut être commandé une fois par round.",
+          "customText": "",
+          "cardName": "Droïde de Combat Rouge"
+        },
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Battle Droid Red",
+              "GUID": "258c0b70-8658-4611-a9e4-240764214c2d",
+              "theText": "Le vieux droïde de combat délabré est recouvert d'une fine couche de poussière.",
+              "buttonList": []
+            },
+            {
+              "entityName": "Terminal Red",
+              "GUID": "d85696f9-e930-4eae-a791-e8dc89de8054",
+              "theText": "Un des terminaux contrôlant le système de sécurité de l'usine.\r\n\r\n{-} Une figurine Rebelle peut interagir avec un terminal ({I} ou {J}). Si elle réussit, cette figurine s'approprie le terminal. Sinon, défaussez ce terminal.",
+              "buttonList": [
+                {
+                  "GUID": "9ebad6b9-2225-4b7b-924a-02b9864b6715",
+                  "theText": "{A} Pirater"
+                }
+              ]
+            }
+          ],
+          "GUID": "8fb3412e-5055-4122-a980-488b0f9e6ac9",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "TBlue Attempt",
+      "GUID": "29742c5e-45fe-4ada-9278-1ed24ba4ff91",
+      "eventText": "",
+      "eventActions": [
+        {
+          "mainText": "Vous commencez à pirater le terminal.\r\n\r\nEffectuez un test {J} ou {I}. Appliquez +1 {B} au test pour chaque pion Stress présent sur le terminal, puis défaussez ces pions Stress. Entrez le nombre de réussites ci-dessous.",
+          "failText": "",
+          "inputList": [
+            {
+              "GUID": "7c64824b-f707-4329-9650-e921d40dc5ee",
+              "theText": ""
+            },
+            {
+              "GUID": "4311e69c-8ee9-44bf-9655-6c050c5be130",
+              "theText": null
+            }
+          ],
+          "GUID": "58484a42-b173-48cc-b547-b5410b2cbaec",
+          "eventActionType": 20,
+          "eaName": "Input Prompt"
+        }
+      ]
+    },
+    {
+      "eventName": "TBlue Discard",
+      "GUID": "20732f2c-60bf-4512-ba67-9390574b7264",
+      "eventText": "Vous ne parvenez pas à pirater le terminal, vous décidez donc de le détruire pour déverrouiller la porte.\r\n\r\n{-} Défaussez le terminal.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Terminal Blue",
+              "GUID": "ef07c100-0ef0-4ab8-9f13-571565864f14",
+              "theText": "Un des terminaux contrôlant le système de sécurité de l'usine.\r\n\r\n{-} Une figurine Rebelle peut interagir avec un terminal ({I} ou {J}). Si elle réussit, cette figurine s'approprie le terminal. Sinon, défaussez ce terminal.",
+              "buttonList": [
+                {
+                  "GUID": "d6929062-b6b2-4225-91e6-6c6daa64817c",
+                  "theText": "{A} Pirater"
+                }
+              ]
+            }
+          ],
+          "GUID": "4f790e3f-f52d-40b9-8702-1fc24261a674",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        },
+        {
+          "tbText": "Maintenant que le terminal n'est plus là, un des vieux droïdes de combat est vraiment devenu inutile.\r\n\r\n{-} Défaussez le droïde de combat bleu.",
+          "GUID": "e57ff15d-e185-4883-ac0f-b479d9c2e7c8",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Battle Droid Blue",
+              "GUID": "27b1379d-d021-4172-b476-bb5b54fa8d0d",
+              "theText": "Le vieux droïde de combat délabré est recouvert d'une fine couche de poussière.",
+              "buttonList": []
+            }
+          ],
+          "GUID": "af78c619-5334-4157-9e4e-2241d35752df",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "TBlue Claim",
+      "GUID": "43cb9e71-3bed-4e07-9d67-c7f2c7a38df2",
+      "eventText": "Vous parvenez à pirater le terminal. Vous en prenez le contrôle et désactivez une partie de la serrure.\r\n\r\n{-} Vous vous appropriez le terminal.",
+      "eventActions": [
+        {
+          "tbText": "Non loin de vous, un droïde de combat en léthargie depuis des dizaines d'années bourdonne et reprend vie. Il porte un fusil blaster rouillé et pose les yeux sur vous.\r\n\r\n{-} Une fois durant son activation, un héros peut commander le droïde de combat bleu. Ce héros peut pousser le droïde de combat jusqu'à 3 cases. Ensuite, il peut choisir une figurine à 3 cases ou moins du droïde de combat dans sa ligne de vue. Lancez 1 dé bleu. Cette figurine subit autant de {H} que de {H} obtenus. Chaque droïde de combat peut être commandé une fois par round.",
+          "GUID": "b00a98e3-75a1-4db3-af29-b347c6986d29",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "GUID": "bd055837-1ef9-436e-bd05-8252b803d28c",
+          "eventActionType": 21,
+          "eaName": "Custom Deployment: Blue Battle Droid",
+          "repositionInstructions": "",
+          "surges": "",
+          "bonuses": "",
+          "keywords": "",
+          "abilities": "DROÏDE DE COMBAT : Une fois durant son activation, un héros peut commander le droïde de combat bleu. Ce héros peut pousser le droïde de combat jusqu'à 3 cases. Ensuite, il peut choisir une figurine à 3 cases ou moins du droïde de combat dans sa ligne de vue. Lancez 1 dé bleu. Cette figurine subit autant de {H} que de {H} obtenus. Chaque droïde de combat peut être commandé une fois par round.",
+          "customText": "",
+          "cardName": "Droïde de Combat Bleu"
+        },
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Battle Droid Blue",
+              "GUID": "c86b644c-fc6b-4aeb-9d86-087839313ddf",
+              "theText": "Le vieux droïde de combat délabré est recouvert d'une fine couche de poussière.",
+              "buttonList": []
+            },
+            {
+              "entityName": "Terminal Blue",
+              "GUID": "21ec5fbf-cd87-4019-9939-3167f996fb7d",
+              "theText": "Un des terminaux contrôlant le système de sécurité de l'usine.\r\n\r\n{-} Une figurine Rebelle peut interagir avec un terminal ({I} ou {J}). Si elle réussit, cette figurine s'approprie le terminal. Sinon, défaussez ce terminal.",
+              "buttonList": [
+                {
+                  "GUID": "e5938d9f-c43c-4517-8535-ed3c0016e8d6",
+                  "theText": "{A} Pirater"
+                }
+              ]
+            }
+          ],
+          "GUID": "dd33adad-7b50-4320-902d-d47efba7e311",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "TGreen Attempt",
+      "GUID": "11bf9b95-378f-4a6f-afb5-6566b8f0d66d",
+      "eventText": "",
+      "eventActions": [
+        {
+          "mainText": "Vous commencez à pirater le terminal.\r\n\r\nEffectuez un test {J} ou {I}. Appliquez +1 {B} au test pour chaque pion Stress présent sur le terminal, puis défaussez ces pions Stress. Entrez le nombre de réussites ci-dessous.",
+          "failText": "",
+          "inputList": [
+            {
+              "GUID": "1e90e801-ed3e-4205-a621-b15769ebf670",
+              "theText": ""
+            },
+            {
+              "GUID": "7852162b-5245-4069-a3f0-ff52cae77941",
+              "theText": null
+            }
+          ],
+          "GUID": "4129a6bd-3562-4fd5-bd56-731f9e29974d",
+          "eventActionType": 20,
+          "eaName": "Input Prompt"
+        }
+      ]
+    },
+    {
+      "eventName": "TGreen Discard",
+      "GUID": "2f811145-5df8-47d3-9d57-f7dd0e9889b3",
+      "eventText": "Vous ne parvenez pas à pirater le terminal, vous décidez donc de le détruire pour déverrouiller la porte.\r\n\r\n{-} Défaussez le terminal.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Terminal Green",
+              "GUID": "33cfe8c3-26f1-46b3-80ea-2b13be93c3ab",
+              "theText": "Un des terminaux contrôlant le système de sécurité de l'usine.\r\n\r\n{-} Une figurine Rebelle peut interagir avec un terminal ({I} ou {J}). Si elle réussit, cette figurine s'approprie le terminal. Sinon, défaussez ce terminal.",
+              "buttonList": [
+                {
+                  "GUID": "135b3560-66d4-4cc5-bb34-00a9e1040c7b",
+                  "theText": "{A} Pirater"
+                }
+              ]
+            }
+          ],
+          "GUID": "d5336037-4805-4691-b17b-acae3fb03282",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        },
+        {
+          "tbText": "Maintenant que le terminal n'est plus là, un des vieux droïdes de combat est vraiment devenu inutile.\r\n\r\n{-} Défaussez le droïde de combat vert.",
+          "GUID": "941f1d0a-2fb7-41c4-988b-8d465a234496",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Battle Droid Green",
+              "GUID": "0f869b86-427a-49ba-8731-a009479d42e7",
+              "theText": "Le vieux droïde de combat délabré est recouvert d'une fine couche de poussière.",
+              "buttonList": []
+            }
+          ],
+          "GUID": "73cb51db-d241-4ad6-adff-099a8dd0bd34",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "TGreen Claim",
+      "GUID": "c41e9742-1934-4240-a8cd-40da0b3cc025",
+      "eventText": "Vous parvenez à pirater le terminal. Vous en prenez le contrôle et désactivez une partie de la serrure.\r\n\r\n{-} Vous vous appropriez le terminal.",
+      "eventActions": [
+        {
+          "tbText": "Non loin de vous, un droïde de combat en léthargie depuis des dizaines d'années bourdonne et reprend vie. Il porte un fusil blaster rouillé et pose les yeux sur vous.\r\n\r\n{-} Une fois durant son activation, un héros peut commander le droïde de combat vert. Ce héros peut pousser le droïde de combat jusqu'à 3 cases. Ensuite, il peut choisir une figurine à 3 cases ou moins du droïde de combat dans sa ligne de vue. Lancez 1 dé bleu. Cette figurine subit autant de {H} que de {H} obtenus. Chaque droïde de combat peut être commandé une fois par round.",
+          "GUID": "18f3beb2-4a50-4345-b22c-4d2905e4d5c5",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "GUID": "0f6e446f-52d9-4c7f-a5a5-7497ba1d2985",
+          "eventActionType": 21,
+          "eaName": "Custom Deployment: Green Battle Droid",
+          "repositionInstructions": "",
+          "surges": "",
+          "bonuses": "",
+          "keywords": "",
+          "abilities": "DROÏDE DE COMBAT : Une fois durant son activation, un héros peut commander le droïde de combat vert. Ce héros peut pousser le droïde de combat jusqu'à 3 cases. Ensuite, il peut choisir une figurine à 3 cases ou moins du droïde de combat dans sa ligne de vue. Lancez 1 dé bleu. Cette figurine subit autant de {H} que de {H} obtenus. Chaque droïde de combat peut être commandé une fois par round.",
+          "customText": "",
+          "cardName": "Droïde de Combat Vert"
+        },
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Terminal Green",
+              "GUID": "432dc1f1-4978-465f-97de-1a39788f3395",
+              "theText": "Un des terminaux contrôlant le système de sécurité de l'usine.\r\n\r\n{-} Une figurine Rebelle peut interagir avec un terminal ({I} ou {J}). Si elle réussit, cette figurine s'approprie le terminal. Sinon, défaussez ce terminal.",
+              "buttonList": [
+                {
+                  "GUID": "448b7fe8-2427-4155-a63b-1b2a68edf6e8",
+                  "theText": "{A} Pirater"
+                }
+              ]
+            },
+            {
+              "entityName": "Battle Droid Green",
+              "GUID": "bd9e2a7c-7495-44e0-a878-16a94eaf8efb",
+              "theText": "Le vieux droïde de combat délabré est recouvert d'une fine couche de poussière.",
+              "buttonList": []
+            }
+          ],
+          "GUID": "0753bcc8-9944-45a4-b531-0866bfd34e29",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "Mission Info Terminals",
+      "GUID": "c6187273-f7b2-41cf-992b-b94965ad6eb3",
+      "eventText": "",
+      "eventActions": [
+        {
+          "theText": "{-} La porte est verrouillée. Elle s'ouvre quand tous les terminaux ont été appropriés ou défaussés.\r\n{-} Une figurine Rebelle peut interagir avec un terminal ({I} ou {J}). Si elle réussit, cette figurine s'approprie le terminal. Sinon, défaussez ce terminal.\r\n{-} Une fois durant son activation, un héros peut commander un droïde de combat de la même couleur qu'un terminal approprié. Ce héros peut pousser le droïde de combat jusqu'à 3 cases. Ensuite, il peut choisir une figurine à 3 cases ou moins du droïde de combat dans sa ligne de vue. Lancez 1 dé bleu. Cette figurine subit autant de X que de X obtenus. Chaque droïde de combat peut être commandé une fois par round.\r\n{-} Quand un héros se replie, il est neutralisé à la place. Quand il est activé, il ne reçoit que 1 action et ne peut utiliser cette action que pour effectuer un déplacement.\r\n{-} La mission évolue quand tous les terminaux ont été appropriés ou défaussés.\r\n{-} Les Rebelles perdent si tous les héros ne sont pas sur la Zone d'Extraction à la fin du Round 6, ou quand tous les héros sont blessés. (Si la limite de Rounds est désactivée, les héros peuvent quitter les lieux pendant des Rounds ultérieurs.)",
+          "GUID": "c02444be-2a2d-4168-9849-ddbae4e0029e",
+          "eventActionType": 1,
+          "eaName": "Change Mission Info"
+        }
+      ]
+    },
+    {
+      "eventName": "Worse all the time",
+      "GUID": "962e3fd2-113c-40d0-825a-0a473968e640",
+      "eventText": "",
+      "eventActions": []
+    },
+    {
+      "eventName": "WatT Hondo",
+      "GUID": "dc260d7f-3ee5-488a-b53c-5bc77d5f7c15",
+      "eventText": "Alors que vous vous frayez un chemin dans le complexe, une silhouette familière surgit soudain de l'ombre. \"Bonjour, bonjour, mes amis !\", dit Hondo Ohnaka. \"Je suis vraiment désolé que nos chemins se croisent à nouveau, mais peut-être pouvons-nous trouver un arrangement ?\" Il lève son blaster.",
+      "eventActions": [
+        {
+          "enemyName": null,
+          "customText": "",
+          "modification": "+*1* Santé",
+          "repositionInstructions": "",
+          "GUID": "f305a879-a084-4731-845d-10a07247ea49",
+          "eventActionType": 6,
+          "eaName": "Deploy: DG086/Hondo Ohnaka"
+        }
+      ]
+    },
+    {
+      "eventName": "WatT Thrawn",
+      "GUID": "1e3d181a-f6a3-4921-bca2-bdf9d9f682d4",
+      "eventText": "Alors que vous vous frayez un chemin dans le complexe, vos yeux tombent sur un homme à la peau bleue vêtu d'un uniforme blanc impeccable. \"Ah, comme c'était prévisible de votre part de tomber dans une de mes pièges. Encore une fois\", dit Thrawn. \"Il est temps de mettre fin à ce triste spectacle.\" Il dégaine son blaster.",
+      "eventActions": [
+        {
+          "enemyName": null,
+          "customText": "",
+          "modification": "+*1* Santé",
+          "repositionInstructions": "",
+          "GUID": "e013773a-4b5e-4ed9-888c-028fa59fc8d1",
+          "eventActionType": 6,
+          "eaName": "Deploy: DG085/Thrawn"
+        }
+      ]
+    },
+    {
+      "eventName": "Cornered 1",
+      "GUID": "e7ccf2fb-4ce9-470d-aae1-f559432c478b",
+      "eventText": "Des alarmes retentissent dans l'usine.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "DP Green 1",
+              "GUID": "6a681f3e-69a5-417e-979c-4d144a389e5e",
+              "theText": null,
+              "buttonList": []
+            },
+            {
+              "entityName": "DP Green 2",
+              "GUID": "7b083a64-82c3-4103-9ddd-67f553c6003f",
+              "theText": null,
+              "buttonList": []
+            },
+            {
+              "entityName": "DP Green 3",
+              "GUID": "b8817e9e-31d0-471a-a8f3-81a927e004d6",
+              "theText": null,
+              "buttonList": []
+            },
+            {
+              "entityName": "DP Yellow 1",
+              "GUID": "e12b1ea2-1c4f-43e7-9f00-8cbf8afda298",
+              "theText": null,
+              "buttonList": []
+            },
+            {
+              "entityName": "DP Yellow 2",
+              "GUID": "6b20486a-14e4-44cf-9a1c-87f8eb726de9",
+              "theText": null,
+              "buttonList": []
+            }
+          ],
+          "GUID": "6ebf6e3a-35b0-4ca0-8822-9eadbc1bc30e",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "Cornered 2",
+      "GUID": "ac3f446b-5e54-4e5f-9864-faa050965cce",
+      "eventText": "Des alarmes retentissent dans l'usine.",
+      "eventActions": []
+    },
+    {
+      "eventName": "Extraction",
+      "GUID": "1ae91c16-dffd-4507-871c-b5b5fff97505",
+      "eventText": "La porte s'ouvre sur le désert poussiéreux de Géonosis. Les coordonnées de votre point d'extraction se trouvent à proximité.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Door 1",
+              "GUID": "deb84291-495a-4e23-8a9e-9e284b0a6c9b",
+              "theText": "La porte de sortie de l'usine de droïdes est fermement verrouillée.\r\n\r\n{-} La porte s'ouvre quand tous les terminaux ont été appropriés ou défaussés.",
+              "buttonList": []
+            }
+          ],
+          "GUID": "9b88df76-aa67-4d16-b19a-49b667690c94",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        },
+        {
+          "tbText": "{-} La case verte en surbrillance est la Zone d'Extraction.\r\n{-} La mission s'achève à la fin du round 6. À ce moment, si tous les héros sont sur la Zone d'Extraction (case verte en surbrillance), les héros quittent les lieux et gagnent la mission. (Si la limite de Rounds est désactivée, les héros peuvent quitter les lieux pendant des Rounds ultérieurs.)",
+          "GUID": "09de7c94-d87b-4696-977c-8f305d15f56b",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "repositionText": "Bloquer l'accès à la Zone d'Extraction.",
+          "GUID": "96ec33e3-b9b5-43fd-8378-a12f61768542",
+          "eventActionType": 17,
+          "eaName": "Change Reposition Instructions"
+        },
+        {
+          "shortText": "Aller sur la Zone d'Extraction et tenir position jusqu'à la fin du Round 6.",
+          "longText": null,
+          "GUID": "c58aa4ab-e00f-4c8b-9049-b983b91ccfc3",
+          "eventActionType": 2,
+          "eaName": "Change Objective"
+        },
+        {
+          "theText": "{-} Une fois durant son activation, un héros peut commander un droïde de combat de la même couleur qu'un terminal approprié. Ce héros peut pousser le droïde de combat jusqu'à 3 cases. Ensuite, il peut choisir une figurine à 3 cases ou moins du droïde de combat dans sa ligne de vue. Lancez 1 dé bleu. Cette figurine subit autant de X que de X obtenus. Chaque droïde de combat peut être commandé une fois par round.\r\n{-} Quand un héros se replie, il est neutralisé à la place. Quand il est activé, il ne reçoit que 1 action et ne peut utiliser cette action que pour effectuer un déplacement.\r\n{-} La mission s'achève à la fin du round 6. À ce moment, si tous les héros sont sur la Zone d'Extraction (case verte en surbrillance), les héros quittent les lieux et gagnent la mission. (Si la limite de Rounds est désactivée, les héros peuvent quitter les lieux pendant des Rounds ultérieurs.)\r\n{-} Les Rebelles perdent quand tous les héros sont blessés.",
+          "GUID": "6674eb38-1357-4a28-b06d-c1da08f7518a",
+          "eventActionType": 1,
+          "eaName": "Change Mission Info"
+        },
+        {
+          "mainText": "Quel est le niveau de menace ?",
+          "failText": "",
+          "inputList": [
+            {
+              "GUID": "f4141352-f2cd-4c98-b0d5-52fcbeba09e3",
+              "theText": null
+            },
+            {
+              "GUID": "b00a25c5-f157-4b1d-8253-71faeb50cce9",
+              "theText": null
+            },
+            {
+              "GUID": "efefbffd-888e-4b6e-859a-81f7b84697a6",
+              "theText": null
+            }
+          ],
+          "GUID": "5aea5a38-f3cf-4dcf-8ec0-56659ef647b6",
+          "eventActionType": 20,
+          "eaName": "Input Prompt"
+        }
+      ]
+    },
+    {
+      "eventName": "Deploy 2",
+      "GUID": "ba84f672-25cc-4c27-86cb-7710e5c1aa96",
+      "eventText": "Des ennemis vous attendent déjà.",
+      "eventActions": [
+        {
+          "enemyName": null,
+          "customText": "",
+          "modification": null,
+          "repositionInstructions": "",
+          "GUID": "c3956fd1-80eb-4c80-b9ed-693e7bae2130",
+          "eventActionType": 6,
+          "eaName": "Deploy: DG058/Death Trooper (Elite)"
+        }
+      ]
+    },
+    {
+      "eventName": "Deploy 3-4",
+      "GUID": "67319351-d255-4cb7-a782-3e08ad06ee63",
+      "eventText": "Des ennemis vous attendent déjà.",
+      "eventActions": [
+        {
+          "enemyName": null,
+          "customText": "",
+          "modification": null,
+          "repositionInstructions": "",
+          "GUID": "c1928ba9-4ecc-47e2-9899-ae6940087a5d",
+          "eventActionType": 6,
+          "eaName": "Deploy: DG058/Death Trooper (Elite)"
+        },
+        {
+          "enemyName": null,
+          "customText": "",
+          "modification": null,
+          "repositionInstructions": "",
+          "GUID": "33192909-87b8-40ed-8a72-e48175f36193",
+          "eventActionType": 6,
+          "eaName": "Deploy: DG056/Death Trooper"
+        }
+      ]
+    },
+    {
+      "eventName": "Deploy 5-6",
+      "GUID": "9769880a-7fcd-4763-aa32-b9b523378882",
+      "eventText": "Des ennemis vous attendent déjà.",
+      "eventActions": [
+        {
+          "enemyName": null,
+          "customText": "",
+          "modification": null,
+          "repositionInstructions": "",
+          "GUID": "975e7a8b-fb9d-4b1d-a6f2-7e5ef9aa5c05",
+          "eventActionType": 6,
+          "eaName": "Deploy: DG058/Death Trooper (Elite)"
+        },
+        {
+          "enemyName": null,
+          "customText": "",
+          "modification": null,
+          "repositionInstructions": "",
+          "GUID": "d93c9d5a-cd71-4d83-8145-596241bd27f2",
+          "eventActionType": 6,
+          "eaName": "Deploy: DG056/Death Trooper"
+        },
+        {
+          "enemyName": null,
+          "customText": "",
+          "modification": null,
+          "repositionInstructions": "",
+          "GUID": "34efcd97-fcf0-47a8-8dfa-ce4a02bc1bda",
+          "eventActionType": 6,
+          "eaName": "Deploy: DG057/Death Trooper"
+        }
+      ]
+    },
+    {
+      "eventName": "End of Mission",
+      "GUID": "9e2775ce-1cf5-450e-8d64-df4a9cb52caa",
+      "eventText": "",
+      "eventActions": [
+        {
+          "mainText": "Tous les héros sont-ils sur la Zone d'Extraction ?",
+          "buttonList": [
+            {
+              "GUID": "23b5a5e8-59e7-4d8f-8933-71e2a57a2ce3",
+              "theText": "Oui"
+            },
+            {
+              "GUID": "112dcd59-b744-4f7c-b2a8-d2212acde381",
+              "theText": "Non"
+            }
+          ],
+          "GUID": "2b8e1b19-cc68-4ba4-a37c-0cefbb73b35f",
+          "eventActionType": 5,
+          "eaName": "Question Prompt"
+        }
+      ]
+    },
+    {
+      "eventName": "Round 6",
+      "GUID": "2b406c66-fc51-4943-ad65-160b0edb91e0",
+      "eventText": "",
+      "eventActions": []
+    }
+  ],
+  "mapEntities": [
+    {
+      "entityName": "Crate1",
+      "GUID": "dcf1e03e-e328-4f79-8427-e0a0bfc64f82",
+      "mainText": "Une vieille caisse de ravitaillement.",
+      "buttonList": [
+        {
+          "GUID": "96d725c5-2d79-4c56-9f23-b604d1f16fab",
+          "theText": "{A} Ouvrir"
+        }
+      ]
+    },
+    {
+      "entityName": "Crate2",
+      "GUID": "461e69e0-7c26-42a1-ad2a-a5e71b4f7707",
+      "mainText": "Une vieille caisse de ravitaillement.",
+      "buttonList": [
+        {
+          "GUID": "f7ea7eec-7b91-4971-bdad-1fc331b5d228",
+          "theText": "{A} Ouvrir"
+        }
+      ]
+    },
+    {
+      "entityName": "Crate3",
+      "GUID": "1e60bee2-7e72-4f71-8c0e-45b5a2d0baf8",
+      "mainText": "Une vieille caisse de ravitaillement.",
+      "buttonList": [
+        {
+          "GUID": "68aa0920-4aef-4612-ba53-b5aa06ec1002",
+          "theText": "{A} Ouvrir"
+        }
+      ]
+    },
+    {
+      "entityName": "Entrance",
+      "GUID": "a343a128-3b10-48ff-878f-71c89176d776",
+      "mainText": "Déployer les héros ici.",
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Green 1",
+      "GUID": "c8062d94-a52f-4458-b2cf-3c7b515747e5",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Green 2",
+      "GUID": "5bdffef2-c7c7-4e16-ab66-dca82b0481fd",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Green 3",
+      "GUID": "64b4dbf2-4e39-4ce7-a5fe-94eed25c16d2",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP EProbe Droid",
+      "GUID": "81ead058-7663-414c-aed5-13a096cc71f9",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Officer",
+      "GUID": "7357ce0b-b055-40fc-af3f-0d2da49d0913",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Trooper 1",
+      "GUID": "bdccea37-8778-4ba6-af29-122920e59956",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Trooper 2",
+      "GUID": "7a768ba2-6d75-4811-a15b-1f7fa644fbf6",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Trooper 3",
+      "GUID": "9e2b5f92-173d-4407-abff-c929797c1728",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Yellow 1",
+      "GUID": "ad72fd77-9da6-4426-8e81-35779402dab3",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Yellow 2",
+      "GUID": "13e2844a-de7d-4b18-ab81-83033b8d01c7",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Red",
+      "GUID": "d61d4769-096c-4e8b-9542-9130b92fc6db",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "Door 1",
+      "GUID": "a0767ee8-730e-4342-9f71-8597aa1c12b5",
+      "mainText": "La porte de sortie de l'usine de droïdes est fermement verrouillée.\r\n\r\n{-} La porte s'ouvre quand tous les terminaux ont été appropriés ou défaussés.",
+      "buttonList": []
+    },
+    {
+      "entityName": "Extraction 1",
+      "GUID": "0421cf55-c9f2-46b4-8e5b-489274cb5c3e",
+      "mainText": "Les coordonnées de votre extraction mènent à cet endroit.\r\n\r\n{-} À la fin du round 6, si tous les héros sont sur la Zone d'Extraction, les héros quittent les lieux et gagnent la mission.",
+      "buttonList": []
+    },
+    {
+      "entityName": "Extraction 2",
+      "GUID": "f38a5283-8681-4d68-8cbd-7187f3214c75",
+      "mainText": "Les coordonnées de votre extraction mènent à cet endroit.\r\n\r\n{-} À la fin du round 6, si tous les héros sont sur la Zone d'Extraction, les héros quittent les lieux et gagnent la mission.",
+      "buttonList": []
+    },
+    {
+      "entityName": "Extraction 3",
+      "GUID": "dd7a349c-84c3-4c30-8942-83e2cd481bdb",
+      "mainText": "Les coordonnées de votre extraction mènent à cet endroit.\r\n\r\n{-} À la fin du round 6, si tous les héros sont sur la Zone d'Extraction, les héros quittent les lieux et gagnent la mission.",
+      "buttonList": []
+    },
+    {
+      "entityName": "Terminal Red",
+      "GUID": "e105f1c2-89e3-4f69-85a6-e14979fec98b",
+      "mainText": "Un des terminaux contrôlant le système de sécurité de l'usine.\r\n\r\n{-} Une figurine Rebelle peut interagir avec un terminal ({I} ou {J}). Si elle réussit, cette figurine s'approprie le terminal. Sinon, défaussez ce terminal.",
+      "buttonList": [
+        {
+          "GUID": "be6223b5-29fa-4a3b-b9c4-f2ddbe95a47f",
+          "theText": "{A} Pirater"
+        }
+      ]
+    },
+    {
+      "entityName": "Battle Droid Red",
+      "GUID": "139eeb89-9462-4f29-9082-33cebb647894",
+      "mainText": "Le vieux droïde de combat délabré est recouvert d'une fine couche de poussière.",
+      "buttonList": []
+    },
+    {
+      "entityName": "Terminal Blue",
+      "GUID": "c29dedd3-5a24-4fcb-852f-44f32ae69e29",
+      "mainText": "Un des terminaux contrôlant le système de sécurité de l'usine.\r\n\r\n{-} Une figurine Rebelle peut interagir avec un terminal ({I} ou {J}). Si elle réussit, cette figurine s'approprie le terminal. Sinon, défaussez ce terminal.",
+      "buttonList": [
+        {
+          "GUID": "c0908abd-bd72-4378-80a2-b1ce1c0bbf2b",
+          "theText": "{A} Pirater"
+        }
+      ]
+    },
+    {
+      "entityName": "Battle Droid Blue",
+      "GUID": "0fe0c266-c429-4fa2-8790-90659814879d",
+      "mainText": "Le vieux droïde de combat délabré est recouvert d'une fine couche de poussière.",
+      "buttonList": []
+    },
+    {
+      "entityName": "Terminal Green",
+      "GUID": "eada085f-6ce6-4f91-8ad3-af98a86cca5e",
+      "mainText": "Un des terminaux contrôlant le système de sécurité de l'usine.\r\n\r\n{-} Une figurine Rebelle peut interagir avec un terminal ({I} ou {J}). Si elle réussit, cette figurine s'approprie le terminal. Sinon, défaussez ce terminal.",
+      "buttonList": [
+        {
+          "GUID": "0065d00b-ba34-4bd6-b09a-c83a2758ceb0",
+          "theText": "{A} Pirater"
+        }
+      ]
+    },
+    {
+      "entityName": "Battle Droid Green",
+      "GUID": "9b2c0e82-97da-458f-98b7-c4ae63d9ad97",
+      "mainText": "Le vieux droïde de combat délabré est recouvert d'une fine couche de poussière.",
+      "buttonList": []
+    }
+  ],
+  "initialGroups": [
+    {
+      "cardName": "Stormtrooper",
+      "customInstructions": ""
+    },
+    {
+      "cardName": "Imperial Officer",
+      "customInstructions": ""
+    },
+    {
+      "cardName": "Probe Droid (Elite)",
+      "customInstructions": ""
+    }
+  ]
+}

--- a/ImperialCommander2/Assets/Resources/Languages/Fr/Missions/Lothal/LOTHAL6_FR.json
+++ b/ImperialCommander2/Assets/Resources/Languages/Fr/Missions/Lothal/LOTHAL6_FR.json
@@ -1,0 +1,855 @@
+{
+  "languageID": "French (FR)",
+  "missionProperties": {
+    "missionName": "L'Ordre final",
+    "missionDescription": "Si vous jouez une mini-campagne, les héros doivent emmener un allié Spectre qu'ils n'ont pas déjà emmené lors d'une mission de cette mini-campagne. ==== Un ingénieur Impérial de Lothal souhaite déserter. De plus, il prétend savoir où nous pouvons trouver des informations vitales concernant les projets du Grand Amiral Thrawn pour le système de Lothal. Vos ordres sont de vérifier ce qu'il en est réellement et, si nécessaire, de mettre fin aux plans de Thrawn, quels qu'ils soient.",
+    "missionInfo": "",
+    "campaignName": "Tyrans de Lothal",
+    "startingObjective": "",
+    "repositionOverride": "Bloquer l'accès à la Chambre des Données.",
+    "additionalMissionInfo": "Si vous jouez une mini-campagne, les héros doivent emmener un allié Spectre qu'ils n'ont pas déjà emmené lors d'une mission de cette mini-campagne."
+  },
+  "events": [
+    {
+      "eventName": "Open Crate 1",
+      "GUID": "2dec36b9-ce77-4bf6-8c35-9489e6573609",
+      "eventText": "Vous fouillez la caisse et prenez ce qui vous semble utile.\r\n\r\nPiochez une carte Ravitaillement. Vous gagnez 1 médipack. Récupérez ce pion.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Crate1",
+              "GUID": "8d3841d9-4db5-4ee4-94b7-125a2f43f778",
+              "theText": "Une vieille caisse de ravitaillement.",
+              "buttonList": [
+                {
+                  "GUID": "ae7c7afe-d50e-40b1-98ee-09b8440ff723",
+                  "theText": "{A} Ouvrir"
+                }
+              ]
+            }
+          ],
+          "GUID": "8eb6c4bb-fd64-4ae8-9b6d-a5ba3f737e6a",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "Open Crate 2",
+      "GUID": "74bbaee9-47db-48c2-b09c-7d0940adf6ab",
+      "eventText": "Vous fouillez la caisse et prenez ce qui vous semble utile.\r\n\r\nPiochez une carte Ravitaillement. Vous gagnez 1 médipack. Récupérez ce pion.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Crate2",
+              "GUID": "cc1dd533-7b86-4afe-80f5-28a16f28d0a6",
+              "theText": "Une vieille caisse de ravitaillement.",
+              "buttonList": []
+            }
+          ],
+          "GUID": "a6f06d59-b18c-465a-acc1-85db4a122e25",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "Open Crate 3",
+      "GUID": "4c60aea9-45d0-4dbe-9bea-27d51eba9079",
+      "eventText": "Vous fouillez la caisse et prenez ce qui vous semble utile.\r\n\r\nPiochez une carte Ravitaillement. Vous gagnez 1 médipack. Récupérez ce pion.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Crate3",
+              "GUID": "774b1e4d-4b58-42b5-a966-e9873e1446a5",
+              "theText": "Une vieille caisse de ravitaillement.",
+              "buttonList": []
+            }
+          ],
+          "GUID": "50b5bf42-216f-45db-925e-d733f34fdd76",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "Open Crate 4",
+      "GUID": "76a22dbc-227b-4ecd-8252-fd22ac3f7577",
+      "eventText": "Vous fouillez la caisse et prenez ce qui vous semble utile.\r\n\r\nPiochez une carte Ravitaillement. Vous gagnez 1 médipack. Récupérez ce pion.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Crate4",
+              "GUID": "bd65e185-2f7e-49e4-a5ef-021cb83b6c55",
+              "theText": "Une vieille caisse de ravitaillement.",
+              "buttonList": [
+                {
+                  "GUID": "f82ee518-6d69-4966-9ee1-55d29847e6b1",
+                  "theText": "{A} Ouvrir"
+                }
+              ]
+            }
+          ],
+          "GUID": "5d3f9806-368e-4034-981d-86ca38608ffb",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "Mission Briefing",
+      "GUID": "edc56ae0-7e4f-4ecd-9176-26e69bfd835a",
+      "eventText": "Vous rencontrez le transfuge des forces Impériales non loin d'une petite colonie de Lothal. Il vous remet en main propre un cylindre codé et vous révèle la localisation d'une chambre des données Impériale contenant des renseignements d'une importance capitale pour Thrawn.\r\n\r\n{-} Déployez les héros sur la case bleue en surbrillance.",
+      "eventActions": [
+        {
+          "tbText": "Des sentinelles gardent la chambre des données. Même si elles opposent une résistance farouche, vous ne pouvez pas vous défaire du sentiment qu'il s'agit d'une sorte de test, cruel, de vos compétences.\r\n\r\n{-} Mettez de côté *1* pions Mission neutres. Les pions Mission neutres sont des connaissances.",
+          "GUID": "1782c751-a309-4259-8cca-5f447b237f35",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "tbText": "Mais que vous soyez réellement surveillé ou non, l'occasion est trop belle pour la laisser passer.\r\n\r\n{-} La mission évolue au début de la phase de Statut si tous les Rebelles sont dans la Chambre des Données.\r\n{-} Les Rebelles perdent quand tous les héros sont blessés.",
+          "GUID": "cdacb49d-26ae-4cb2-9957-bc9a6849a678",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "newInstructions": "{-} Quand cette figurine déclare une attaque, s'il y a une connaissance mise de côté, placez la sur la fiche du héros ou sur la carte Déploiement de la figurine ciblée, puis appliquez -1 {H} à l'attaque.",
+          "GUID": "f184f1d3-bb4b-40ab-8a2c-896e51ac1b78",
+          "eventActionType": 11,
+          "eaName": "Change Group Instructions"
+        },
+        {
+          "shortText": "Entrer dans la Chambre des Données.",
+          "longText": null,
+          "GUID": "a392947f-57e4-426e-873c-e68f011ac292",
+          "eventActionType": 2,
+          "eaName": "Change Objective"
+        },
+        {
+          "theText": "{-} Les pions Mission neutres sont des connaissances.\r\n{-} La mission évolue au début de la phase de Statut si tous les Rebelles sont dans la Chambre des Données.\r\n{-} Les Rebelles perdent quand tous les héros sont blessés.",
+          "GUID": "472d2c84-10ee-4fdb-b32e-25d81355a746",
+          "eventActionType": 1,
+          "eaName": "Change Mission Info"
+        }
+      ]
+    },
+    {
+      "eventName": "End of Mission - Rebels win",
+      "GUID": "69b80fad-5e0e-46cd-a70e-defa45de4db6",
+      "eventText": "\"Un adversaire plus valeureux que je ne l'avais réalisé\", commente Thrawn en battant en retraite dans une navette qui l'attendait non loin de là.\r\n\r\n{-} Les Rebelles remportent la mission !\r\n{-} Si vous jouez cette mission en tant que Mission annexe, les héros reçoivent 150 crédits par héros.",
+      "eventActions": [
+        {
+          "mainText": "Jouez-vous cette mission dans le cadre de la mini-campagne \"Tyrans de Lothal\" ?",
+          "buttonList": [
+            {
+              "GUID": "dc37bce0-c4dc-4b63-8c46-b2dcddd8e655",
+              "theText": "Oui"
+            },
+            {
+              "GUID": "042ba502-bd32-441a-8202-812f75973120",
+              "theText": "Non"
+            }
+          ],
+          "GUID": "fa160c96-ff1c-4306-ad5f-f40d51ef9331",
+          "eventActionType": 5,
+          "eaName": "Question Prompt"
+        }
+      ]
+    },
+    {
+      "eventName": "End of Mission - Rebels lose",
+      "GUID": "9e960fce-d271-468c-8d6c-233bc752aa52",
+      "eventText": "Les soldats de Thrawn se rapprochent. Il laisse un sourire naître sur son visage tandis que vous combattez désespérément pour éviter d'être capturés.\r\n\r\n{-} Les Rebelles perdent la mission.",
+      "eventActions": [
+        {
+          "mainText": "Jouez-vous cette mission dans le cadre de la mini-campagne \"Tyrans de Lothal\" ?",
+          "buttonList": [
+            {
+              "GUID": "ce63b6a1-527a-4347-900b-826b5249186b",
+              "theText": "Oui"
+            },
+            {
+              "GUID": "a4d1cf53-6662-4106-80a9-468bda273fa6",
+              "theText": "Non"
+            }
+          ],
+          "GUID": "922d0b18-3b9c-4426-b8b1-9d79afd7d873",
+          "eventActionType": 5,
+          "eaName": "Question Prompt"
+        }
+      ]
+    },
+    {
+      "eventName": "Mini campaign Win",
+      "GUID": "1fb0c0b1-7388-42f6-9c4c-801de27f03a5",
+      "eventText": "Le chaos règne sur les environs de la chambre des données Impériale. De la fumée s'échappe de la chambre elle-même tandis que les troopers approchent. Cependant, comme Thrawn est actuellement indisposé, la réaction de l'Empire est confuse et inefficace : le temps qu'ils arrivent, vous êtes partis depuis longtemps.\r\n\r\n\"Vous avez défié le Grand Amiral Thrawn et en êtes sortis vainqueurs. Voilà qui est impressionnant\", commente Hera après que vous lui ayez tout raconté. Elle ne peut s'empêcher de sourire, même si ses sentiments restent manifestement mitigés. \"Thrawn ne vous oubliera pas de sitôt. Lothal n'est plus un endroit sûr pour vous.\" Elle lève la main avant que vous ayez le temps de protester. \"Je pense qu'il est temps que je vous présente quelqu'un.\"\r\n\r\nQuelques semaines plus tard, après avoir voyagé d'un coursier Rebelle à un autre, vous abordez finalement le sol couvert de jungles de la quatrième lune de la planète Yavin. Votre transporteur atterrit dans l'ombre d'un temple imposant et bien plus ancien que cette guerre.\r\n\r\nUn homme attend alors que vous débarquez. Il est âgé et vêtu d'un uniforme. \"La Capitaine Syndulla ne tarit pas d'éloges à votre endroit\", commence-t-il. \"Je suis le général Dodonna. Laissez-moi être le premier à vous le dire : Bienvenue dans l'Alliance Rebelle.\"\r\n\r\n{-} Les Rebelles remportent la campagne !",
+      "eventActions": []
+    },
+    {
+      "eventName": "Mini campaign Defeat",
+      "GUID": "ee9e6f21-9b9f-47ca-b982-44b59453a837",
+      "eventText": "\"Je me dois de faire vos éloges\", déclare Thrawn avec le même ton sec et posé qui vous agace depuis des jours, à force de l'entendre. Il ne vous parle que rarement, mais ses visites vous offrent vos uniques moments de répit, loin de ses interrogateurs. \"Vous savez que les informations que vous possédez ne pourraient nous mener qu'à une poignée d'autres individus. L'avenir des forces Rebelles n'est en rien menacé. Et pourtant...\" Il se retourne pour vous examiner, comme si vous étiez un de ses trophées. \"...même en sachant cela, vous résistez. Vous êtes prêt à mourir pour sauver la vie de tellement peu des vôtres.\"\r\n\r\nThrawn se rapproche. Si vos mains n'étaient pas liées, vous pourriez les tendre pour l'étrangler. \"Je suis prêt à garantir que vous vivrez le reste de votre peine dans un confort relatif. Pour un Rebelle, il s'agit d'une offre peu commune.\"\r\n\r\nVous ne dites rien.\r\n\r\nIl fronce les sourcils. \"Lieutenant\" dit-il en s'adressant à l'interrogateur que vous avez appris à haïr. \"Il me semble que le camp de travail de Wobani a grand besoin de bras supplémentaires. Veillez aux préparatifs pour y transférer ce prisonnier.\" Thrawn passe le seuil de la porte avant de marquer une pause. La lumière du couloir de détention luit sur sa peau bleue. Vous voyez ses yeux rouges briller encore une fois alors qu'il prépare déjà le prochain coup qui doit lui permettre de détruire la Rébellion. \r\n\r\nL'instant d'après, il n'est plus là. Et l'obscurité s'abat de nouveau sur vous.\r\n\r\n{-} Les Rebelles perdent la campagne.",
+      "eventActions": []
+    },
+    {
+      "eventName": "No campaign",
+      "GUID": "8fe1b24a-487b-46a0-9e81-94329508e0dc",
+      "eventText": "{-} Chaque héros reçoit 1 XP.\r\n{-} Les héros reçoivent 100 crédits par héros.",
+      "eventActions": []
+    },
+    {
+      "eventName": "Terminal 1 destroyed",
+      "GUID": "7cfd30bb-fb29-4ecd-b4dd-16838cfb03ea",
+      "eventText": "Le terminal explose dans une pluie d'étincelles.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Terminal 1",
+              "GUID": "f6ed69b7-de75-4ef9-876b-979d51a94c11",
+              "theText": "Le terminal émet un léger bourdonnement pendant qu'il télécharge le flux de données.\r\n\r\n{-} Une figurine Rebelle peut attaquer le terminal (Santé : *2*, Défense : 1 {G}).",
+              "buttonList": [
+                {
+                  "GUID": "e0af9e83-c24f-49fb-8d36-5772a9f462ee",
+                  "theText": "Détruire"
+                }
+              ]
+            }
+          ],
+          "GUID": "491c6b08-a8a8-420c-93d6-c29c851394c0",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "Terminal 2 destroyed",
+      "GUID": "2d4c1d6d-d05a-46b9-8a71-bc6be23d055b",
+      "eventText": "Le terminal explose dans une pluie d'étincelles.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Terminal 2",
+              "GUID": "b107799d-ff84-4549-8abb-6f598904a655",
+              "theText": "Le terminal émet un léger bourdonnement pendant qu'il télécharge le flux de données.\r\n\r\n{-} Une figurine Rebelle peut attaquer le terminal (Santé : *2*, Défense : 1 {G}).",
+              "buttonList": [
+                {
+                  "GUID": "ad806be8-30c4-423d-b6cc-7187a5ddd348",
+                  "theText": "Détruire"
+                }
+              ]
+            }
+          ],
+          "GUID": "3238d093-0270-46e5-843e-ea73b7a7cd01",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "Terminal 3 destroyed",
+      "GUID": "1c1454ba-5779-4786-8073-b112a55b584c",
+      "eventText": "Le terminal explose dans une pluie d'étincelles.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Terminal 3",
+              "GUID": "da77e3c6-ab8d-4954-9a75-239033df53f1",
+              "theText": "Le terminal émet un léger bourdonnement pendant qu'il télécharge le flux de données.\r\n\r\n{-} Une figurine Rebelle peut attaquer le terminal (Santé : *2*, Défense : 1 {G}).",
+              "buttonList": [
+                {
+                  "GUID": "6b21df2b-452b-4b73-ae55-3ee0aa9f4954",
+                  "theText": "Détruire"
+                }
+              ]
+            }
+          ],
+          "GUID": "636e9639-a7b5-4b88-86a2-1537eb0d382f",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "Terminal 4 destroyed",
+      "GUID": "3f456ff9-4df9-4486-b3f9-e503ce941476",
+      "eventText": "Le terminal explose dans une pluie d'étincelles.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Terminal 4",
+              "GUID": "8a9e4263-da37-4e1a-8362-921227ad3c4e",
+              "theText": "Le terminal émet un léger bourdonnement pendant qu'il télécharge le flux de données.\r\n\r\n{-} Une figurine Rebelle peut attaquer le terminal (Santé : *2*, Défense : 1 {G}).",
+              "buttonList": [
+                {
+                  "GUID": "edd826cf-314f-40bb-ac05-a72a76428d86",
+                  "theText": "Détruire"
+                }
+              ]
+            }
+          ],
+          "GUID": "efb91b2a-94e4-4335-8397-74c1301bf3ea",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "Under Surveillance",
+      "GUID": "724d6085-39c1-4005-b46b-d8c75ae8b2a5",
+      "eventText": "Vous ne pouvez pas vous défaire du sentiment que vous êtes toujours surveillés.\r\n\r\n{-} S'il y a une connaissance mise de côté, placez la sur la fiche du héros ou sur la carte Déploiement de {rebel}.",
+      "eventActions": []
+    },
+    {
+      "eventName": "Enter Datavault",
+      "GUID": "04bc805c-1cd3-4316-92fe-0de10e51bab2",
+      "eventText": "La porte de la chambre des données s'ouvre et révèle une grande pièce. Elle est remplie de terminaux et consoles informatiques, mais ils sont éteints et silencieux.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Door Datavault",
+              "GUID": "95c7c418-528b-4628-87cb-be3cc0239424",
+              "theText": "D'après vos données, cette porte mène à la chambre des données de Thrawn.",
+              "buttonList": [
+                {
+                  "GUID": "46d715fc-3b5b-4328-a1f8-06dc359dd22c",
+                  "theText": "{A} Ouvrir"
+                }
+              ]
+            }
+          ],
+          "GUID": "68ace406-80f0-4d93-b9f0-941d9dbfca09",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        },
+        {
+          "tbText": "Une porte mène plus loin dans le complexe. D'après les transmissions de Thrawn, vous reconnaissez qu'il s'agit de la porte qui mène à sa Salle des Trophées.\r\n\r\n{-} La porte de la Salle des Trophées est verrouillée.",
+          "GUID": "99e94ad1-0364-47c9-8d9e-da71fb46c28f",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "theText": "{-} La porte de la Salle des Trophées est verrouillée.\r\n{-} Les pions Mission neutres sont des connaissances.\r\n{-} La mission évolue au début de la phase de Statut si tous les Rebelles sont dans la Chambre des Données.\r\n{-} Les Rebelles perdent quand tous les héros sont blessés.",
+          "GUID": "f8a055ba-1aae-498d-8bd6-e3a47ef550b9",
+          "eventActionType": 1,
+          "eaName": "Change Mission Info"
+        }
+      ]
+    },
+    {
+      "eventName": "EoR Question",
+      "GUID": "be10be23-4959-4c11-b144-f79acddbdaec",
+      "eventText": "",
+      "eventActions": [
+        {
+          "mainText": "Tous les héros sont-ils dans la Chambre des Données ?",
+          "buttonList": [
+            {
+              "GUID": "e42c3802-e14c-482a-bad6-85b8392cb0c1",
+              "theText": "Oui"
+            },
+            {
+              "GUID": "0e208891-4efb-4f34-a275-ea5122d06371",
+              "theText": "Non"
+            }
+          ],
+          "GUID": "2d3df5e0-6042-4911-848b-5d7ca66bc53a",
+          "eventActionType": 5,
+          "eaName": "Question Prompt"
+        }
+      ]
+    },
+    {
+      "eventName": "Thrawn's Snare",
+      "GUID": "57f33a41-9f08-4911-9558-1f3c620dba0a",
+      "eventText": "Les terminaux s'allument. Sur tous les écrans, vous lisez les détails des opérations Rebelles du secteur.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "DP Red 1",
+              "GUID": "47ab2a9e-7645-4a55-8e05-b3f3579ca3c5",
+              "theText": null,
+              "buttonList": []
+            },
+            {
+              "entityName": "DP Red 2",
+              "GUID": "b1237a7d-2558-44f4-b3c2-0c29225ad63a",
+              "theText": null,
+              "buttonList": []
+            },
+            {
+              "entityName": "DP Red 3",
+              "GUID": "112581c8-d514-4a08-9824-4b6750690d3b",
+              "theText": null,
+              "buttonList": []
+            },
+            {
+              "entityName": "DP Green 1",
+              "GUID": "9b3335e3-9635-41a4-8973-6257152f2edd",
+              "theText": null,
+              "buttonList": []
+            },
+            {
+              "entityName": "DP Green 2",
+              "GUID": "fb2bfbdf-a12f-4d5b-aa03-3b427cfdbafb",
+              "theText": null,
+              "buttonList": []
+            },
+            {
+              "entityName": "DP Green 3",
+              "GUID": "09a260eb-e8ad-4d02-8db1-21d8fef6b285",
+              "theText": null,
+              "buttonList": []
+            }
+          ],
+          "GUID": "90e8fc83-1f5f-4094-a318-1313ae6e558b",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        },
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Terminal 1",
+              "GUID": "46f3bc0c-542f-4385-9925-08100e6fa295",
+              "theText": "Le terminal émet un léger bourdonnement pendant qu'il télécharge le flux de données.\r\n\r\n{-} Une figurine Rebelle peut attaquer le terminal (Santé : *2*, Défense : 1 {G}).",
+              "buttonList": [
+                {
+                  "GUID": "cbd0750e-827e-41c4-a7a9-286390be81d7",
+                  "theText": "Détruire"
+                }
+              ]
+            },
+            {
+              "entityName": "Terminal 2",
+              "GUID": "33532ea5-11bb-4cc3-b040-98131cf7dab2",
+              "theText": "Le terminal émet un léger bourdonnement pendant qu'il télécharge le flux de données.\r\n\r\n{-} Une figurine Rebelle peut attaquer le terminal (Santé : *2*, Défense : 1 {G}).",
+              "buttonList": [
+                {
+                  "GUID": "d169bbc2-b638-4966-a13c-9f88fecd7252",
+                  "theText": "Détruire"
+                }
+              ]
+            },
+            {
+              "entityName": "Terminal 3",
+              "GUID": "a4ea0785-1b37-4807-9e2e-aef1ad73a120",
+              "theText": "Le terminal émet un léger bourdonnement pendant qu'il télécharge le flux de données.\r\n\r\n{-} Une figurine Rebelle peut attaquer le terminal (Santé : *2*, Défense : 1 {G}).",
+              "buttonList": [
+                {
+                  "GUID": "fdc0b55f-8ae2-4e8a-9758-6cd9043f60cf",
+                  "theText": "Détruire"
+                }
+              ]
+            },
+            {
+              "entityName": "Terminal 4",
+              "GUID": "efe8252b-0209-4f14-928c-7bc9ca863457",
+              "theText": "Le terminal émet un léger bourdonnement pendant qu'il télécharge le flux de données.\r\n\r\n{-} Une figurine Rebelle peut attaquer le terminal (Santé : *2*, Défense : 1 {G}).",
+              "buttonList": [
+                {
+                  "GUID": "6a0c679e-9c01-42f2-8d6b-cf74de0da562",
+                  "theText": "Détruire"
+                }
+              ]
+            }
+          ],
+          "GUID": "a45faf75-c799-4539-a00c-0319c43e24ee",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        },
+        {
+          "tbText": "Un hologramme du Grand Amiral Thrawn s'anime devant vous. \"Vous progressez de manière impressionnante.\", déclare-t-il, \"mais il est temps de mettre un terme à ce petit jeu\".",
+          "GUID": "787c15e4-d4b5-4fcc-9d4f-c183a5a77234",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "enemyName": null,
+          "customText": "{-} Ignorez l'effet bonus PLANS DE LONGUE DATE.\r\n{-} SURVEILLANCE À DISTANCE : S'il y a une connaissance mise de côté, placez la sur la fiche du héros ou sur la carte Déploiement de {rebel}.\r\n{-} PATIENCE À DISTANCE : Les autres X figurines Impériales avec le coût le plus élevé gagnent 1 {h} et 1 {g}. X est égal au nombre de pions d'activation Rebelle épuisés.\r\n{-} PLANS DE LONGUE DATE À DISTANCE :  Les autres X figurines Impériales avec le coût le plus élevé gagnent 1 {h}. X est égal au nombre actuel de Rounds.",
+          "modification": "+*1* Santé",
+          "repositionInstructions": "",
+          "GUID": "d987fb4a-7108-4e94-81f6-3a57fdcd2f9a",
+          "eventActionType": 6,
+          "eaName": "Deploy: DG085/Thrawn"
+        },
+        {
+          "tbText": "{-} Mettez la figurine de <color=\"red\">Thrawn</color> de côté. Elle n'est pas sur le plateau.",
+          "GUID": "700f4805-7677-4dc9-813e-f31918a7b3d2",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "tbText": "Les ordinateurs de la chambre forte commencent à transmettre les données vers le vaisseau de Thrawn : si le téléchargement était mené à terme, tous les Rebelles à proximité de Lothal pourraient être en danger.\r\n\r\n{-} Une figurine Rebelle peut attaquer un terminal (Santé : *2*, Défense : 1 {G}).\r\n{-} Quand tous les terminaux sont détruits, la transmission des données est interrompue.\r\n{-} La mission évolue quand la transmission des données est interrompue.",
+          "GUID": "37b1172e-d667-46a4-9dfd-7a54caae2a53",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "tbText": "Les forces de Thrawn étaient à l'affût. Elles se précipitent immédiatement à l'intérieur par des portes cachées.",
+          "GUID": "de979791-0961-4af1-9837-110bd262f2a0",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "newInstructions": "{-} Quand cette figurine déclare une attaque, s'il y a une connaissance sur la cible, ajoutez 1 dé rouge à sa réserve d'attaque, puis mettez la connaissance de côté. Sinon, s'il y a une connaissance mise de côté, placez la sur la fiche du héros ou sur la carte Déploiement de la figurine ciblée, puis appliquez -1 {H} à l'attaque.",
+          "GUID": "f55beb25-8003-4cc9-947f-eccd1fdadddb",
+          "eventActionType": 11,
+          "eaName": "Change Group Instructions"
+        },
+        {
+          "repositionText": "Bloquer l'accès aux terminaux.",
+          "GUID": "d78a7d5f-491f-4c34-aae5-c15913ab7fa8",
+          "eventActionType": 17,
+          "eaName": "Change Reposition Instructions"
+        },
+        {
+          "tbText": "La voix de Thrawn grésille dans le comlink. \"Merci pour les données précieuses que j'ai pu recueillir sur votre style de combat\", dit-il calmement. \"Elles me seront très utiles.\"\r\n\r\n{-} Les figurines Impériales peuvent désormais utiliser les connaissances présentes sur les fiche de héros ou cartes Déploiement lorsqu'elles en reçoivent l'instruction.",
+          "GUID": "a3bce6ae-09af-42fb-94b7-b6c39943b64c",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "shortText": "Détruire les terminaux (&Terminals destroyed&/4).",
+          "longText": null,
+          "GUID": "3a58c36f-6a49-414f-882a-41737d798163",
+          "eventActionType": 2,
+          "eaName": "Change Objective"
+        },
+        {
+          "theText": "{-} La porte de la Salle des Trophées est verrouillée.\r\n{-} La porte vers l'extérieur est verrouillée.\r\n{-} Les pions Mission neutres sont des connaissances.\r\n{-} Une figurine Rebelle peut attaquer un terminal (Santé : *2*, Défense : 1 {G}).\r\n{-} Quand tous les terminaux sont détruits, la transmission des données est interrompue.\r\n{-} La mission évolue quand la transmission des données est interrompue.\r\n{-} Les Rebelles perdent quand tous les héros sont blessés.",
+          "GUID": "13012cba-5a28-4bc6-8475-52de06d5f0d5",
+          "eventActionType": 1,
+          "eaName": "Change Mission Info"
+        }
+      ]
+    },
+    {
+      "eventName": "Thrawn's Snare 2",
+      "GUID": "95e8d348-e90d-4a02-a143-49e463771ed0",
+      "eventText": "Poussées par le message de Thrawn, les forces impériales à l'extérieur de la Chambre des Données se précipitent.\r\n\r\n{-} Chacune des figurines Impériales sur un case d'extérieur est poussée vers la case la plus proche de la Chambre des Données.",
+      "eventActions": [
+        {
+          "tbText": "Derrière eux, la porte se referme.\r\n\r\n{-} La porte vers l'extérieur est verrouillée.",
+          "GUID": "ec918d65-897c-43c8-95c7-4e2b3c94a5df",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Door Datavault",
+              "GUID": "e3f3cffb-b66c-419e-991d-eda12b65d72a",
+              "theText": "La porte vers l'extérieur est fermement verrouillée.",
+              "buttonList": []
+            }
+          ],
+          "GUID": "a7538aa0-a037-43c8-82b4-a7421addc40b",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "EoR 7",
+      "GUID": "0a4ab53e-fd4f-4312-82b9-e6e0a405a4b1",
+      "eventText": "",
+      "eventActions": []
+    },
+    {
+      "eventName": "No More Games",
+      "GUID": "fc80e8f6-1f5a-4ed8-9a4f-f970f075d498",
+      "eventText": "Les systèmes de sécurité de la chambre des données s'effondrent. Toutes les portes aux alentours s'ouvrent brusquement. \"Saisissez les Rebelles\" s'écrie Thrawn. Ses gardes du corps lèvent leurs armes.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Door Datavault",
+              "GUID": "5c6a2938-20f8-4f61-899f-14ec18428695",
+              "theText": "D'après vos données, cette porte mène à la chambre des données de Thrawn.",
+              "buttonList": [
+                {
+                  "GUID": "2060c71a-11a4-4685-86a5-42156ee03d75",
+                  "theText": "{A} Ouvrir"
+                }
+              ]
+            },
+            {
+              "entityName": "Door Trophy Room",
+              "GUID": "3a018e47-596d-4b25-9824-93fec15491ba",
+              "theText": "La porte de la Salle des Trophées de Thrawn est fermement verrouillée.",
+              "buttonList": []
+            }
+          ],
+          "GUID": "5cda84db-a15c-44a8-80ff-81564a595e80",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        },
+        {
+          "enemyName": null,
+          "customText": "",
+          "modification": null,
+          "repositionInstructions": "",
+          "GUID": "e7718b25-dee0-491b-9258-d6d65c69e275",
+          "eventActionType": 6,
+          "eaName": "Deploy: DG003/Stormtrooper (Elite)"
+        },
+        {
+          "tbText": "{-} Placez la figurine de <color=\"red\">Thrawn</color> sur la tuile 36A, directement derrière le <color=\"red\">Stormtrooper</color> central.\r\n{-} Quand <color=\"red\">Thrawn</color> est attaqué, s'il y a une connaissance sur l'attaquant, mettez la connaissance de côté et retirez 1 dé d'attaque de sa réserve d'attaque (priorité : rouge, jaune, vert, bleu).\r\n{-} La mission ne s'achève plus à la fin du round 7. \r\n{-} Les Rebelles gagnent quand <color=\"red\">Thrawn</color> est vaincu.",
+          "GUID": "f4ae2939-bccb-4559-bd3a-c3ff37fa5f42",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "newInstructions": "{-} Quand cette figurine déclare une attaque, s'il y a une connaissance sur la cible, ajoutez 1 dé rouge à sa réserve d'attaque, puis mettez la connaissance de côté. Sinon, s'il y a une connaissance mise de côté, placez la sur la fiche du héros ou sur la carte Déploiement de la figurine ciblée, puis appliquez -1 {H} à l'attaque.\r\n{Q} Déplacement de 3 pour attaquer {R1}.\r\n{A} Déplacement de 3 vers la figurine Impériale la plus proche.\r\n{-} PATIENCE : Cette figurine et la figurine Impériale la plus proche avec le coût le plus élevé à X cases ou moins gagnent 1 {h} et 1 {g}. X est égal au nombre de pions d'activation Rebelle épuisés.\r\n{A} Déplacement de 5 pour se repositionner à 3.",
+          "GUID": "e01371aa-7b7f-4cb0-9b43-e4546cefa0da",
+          "eventActionType": 11,
+          "eaName": "Change Group Instructions"
+        },
+        {
+          "repositionText": "Bloquer la ligne de vue vers <color=\"red\">Thrawn</color>.",
+          "GUID": "418bb896-3e13-4656-946a-553cdf987708",
+          "eventActionType": 17,
+          "eaName": "Change Reposition Instructions"
+        },
+        {
+          "shortText": "Vaincre <color=\"red\">Thrawn</color>.",
+          "longText": null,
+          "GUID": "90b69418-7bff-4cb2-9995-9b83e23eb450",
+          "eventActionType": 2,
+          "eaName": "Change Objective"
+        },
+        {
+          "theText": "{-} Les pions Mission neutres sont des connaissances.\r\n{-} Quand <color=\"red\">Thrawn</color> est attaqué, s'il y a une connaissance sur l'attaquant, mettez la connaissance de côté et retirez 1 dé d'attaque de sa réserve d'attaque (priorité : rouge, jaune, vert, bleu).\r\n{-} Les Rebelles gagnent quand <color=\"red\">Thrawn</color> est vaincu.\r\n{-} Les Rebelles perdent quand tous les héros sont blessés.",
+          "GUID": "66c6723e-6159-4d72-ab44-a690c680844a",
+          "eventActionType": 1,
+          "eaName": "Change Mission Info"
+        }
+      ]
+    }
+  ],
+  "mapEntities": [
+    {
+      "entityName": "Crate1",
+      "GUID": "dcf1e03e-e328-4f79-8427-e0a0bfc64f82",
+      "mainText": "Une vieille caisse de ravitaillement.",
+      "buttonList": [
+        {
+          "GUID": "197fc9ef-071a-4a72-b6fb-54baf94cf0fe",
+          "theText": "{A} Ouvrir"
+        }
+      ]
+    },
+    {
+      "entityName": "Crate2",
+      "GUID": "461e69e0-7c26-42a1-ad2a-a5e71b4f7707",
+      "mainText": "Une vieille caisse de ravitaillement.",
+      "buttonList": [
+        {
+          "GUID": "b4a68e3e-adaf-4346-b4a4-9d694293e893",
+          "theText": "{A} Ouvrir"
+        }
+      ]
+    },
+    {
+      "entityName": "Crate3",
+      "GUID": "1e60bee2-7e72-4f71-8c0e-45b5a2d0baf8",
+      "mainText": "Une vieille caisse de ravitaillement.",
+      "buttonList": [
+        {
+          "GUID": "387ba0cb-92b5-49f9-a27c-c72e88d2600e",
+          "theText": "{A} Ouvrir"
+        }
+      ]
+    },
+    {
+      "entityName": "Entrance",
+      "GUID": "a343a128-3b10-48ff-878f-71c89176d776",
+      "mainText": "Déployer les héros ici.",
+      "buttonList": []
+    },
+    {
+      "entityName": "Crate4",
+      "GUID": "3cb4be6e-caea-4e62-8224-09b5c1aa9cba",
+      "mainText": "Une vieille caisse de ravitaillement.",
+      "buttonList": [
+        {
+          "GUID": "eb5835a0-a250-4df1-8de1-17942c66d7d3",
+          "theText": "{A} Ouvrir"
+        }
+      ]
+    },
+    {
+      "entityName": "DP Green 1",
+      "GUID": "c8062d94-a52f-4458-b2cf-3c7b515747e5",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Green 2",
+      "GUID": "5bdffef2-c7c7-4e16-ab66-dca82b0481fd",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Green 3",
+      "GUID": "64b4dbf2-4e39-4ce7-a5fe-94eed25c16d2",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP EDTrooper",
+      "GUID": "81ead058-7663-414c-aed5-13a096cc71f9",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "Door Datavault",
+      "GUID": "25174d45-de3d-4e95-be58-6f5b997f6c1f",
+      "mainText": "D'après vos données, cette porte mène à la chambre des données de Thrawn.",
+      "buttonList": [
+        {
+          "GUID": "9c9c091f-2c0d-4ae0-b718-13f1d25a68ae",
+          "theText": "{A} Ouvrir"
+        }
+      ]
+    },
+    {
+      "entityName": "DP Probe Droid 1",
+      "GUID": "371bcb6a-8f39-4f80-b5a3-0814751d7772",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Probe Droid 2",
+      "GUID": "98d27b1b-3f93-438e-a432-c8105e03b3d7",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Loth 1",
+      "GUID": "8f75e484-24d0-48c8-b261-18d968e36395",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Loth 2",
+      "GUID": "4a3390db-97da-432e-9984-b4cc270c6060",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "Door Trophy Room",
+      "GUID": "8a9f52b4-a3b1-4a84-8045-d187b89809ae",
+      "mainText": "La porte de la Salle des Trophées de Thrawn est fermement verrouillée.",
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Red 1",
+      "GUID": "a8b8e16b-1b80-48cb-a7ed-1591e43be381",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Red 2",
+      "GUID": "a7bca883-f0e0-4c14-9d6f-10549d4545c2",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Red 3",
+      "GUID": "bf53163b-ddb2-46eb-aae0-7f5269847d80",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "Terminal 1",
+      "GUID": "9bfc9cf9-6dbc-400b-80de-fdadd27f593e",
+      "mainText": "Le terminal émet un léger bourdonnement pendant qu'il télécharge le flux de données.\r\n\r\n{-} Une figurine Rebelle peut attaquer le terminal (Santé : *2*, Défense : 1 {G}).",
+      "buttonList": [
+        {
+          "GUID": "cdc16c0c-cc91-4896-8cd3-8abe63d85f69",
+          "theText": "Détruire"
+        }
+      ]
+    },
+    {
+      "entityName": "Terminal 2",
+      "GUID": "ba4f21b9-2733-439e-9edc-d2e104672058",
+      "mainText": "Le terminal émet un léger bourdonnement pendant qu'il télécharge le flux de données.\r\n\r\n{-} Une figurine Rebelle peut attaquer le terminal (Santé : *2*, Défense : 1 {G}).",
+      "buttonList": [
+        {
+          "GUID": "4758338d-a090-4faa-9b7f-6ed216d21748",
+          "theText": "Détruire"
+        }
+      ]
+    },
+    {
+      "entityName": "Terminal 3",
+      "GUID": "5edda759-585b-4331-b704-c39be2d9d633",
+      "mainText": "Le terminal émet un léger bourdonnement pendant qu'il télécharge le flux de données.\r\n\r\n{-} Une figurine Rebelle peut attaquer le terminal (Santé : *2*, Défense : 1 {G}).",
+      "buttonList": [
+        {
+          "GUID": "75d968e8-b01c-4de7-bbe5-efe4b90cb959",
+          "theText": "Détruire"
+        }
+      ]
+    },
+    {
+      "entityName": "Terminal 4",
+      "GUID": "a407dff0-dab5-4e3c-9123-ba31092d1c30",
+      "mainText": "Le terminal émet un léger bourdonnement pendant qu'il télécharge le flux de données.\r\n\r\n{-} Une figurine Rebelle peut attaquer le terminal (Santé : *2*, Défense : 1 {G}).",
+      "buttonList": [
+        {
+          "GUID": "26e84251-1b82-4efd-a800-7c4deaadeae0",
+          "theText": "Détruire"
+        }
+      ]
+    },
+    {
+      "entityName": "DP Trophy Room 1",
+      "GUID": "eaab7cba-dcf9-4370-8524-c3a1e7e03cd7",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Trophy Room 2",
+      "GUID": "e1a94f9c-7b45-4b8d-8f4f-134162dcefdd",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Trophy Room 3",
+      "GUID": "add654d3-cf3c-411c-967f-c08fdf872e3c",
+      "mainText": null,
+      "buttonList": []
+    }
+  ],
+  "initialGroups": [
+    {
+      "cardName": "Death Trooper (Elite)",
+      "customInstructions": ""
+    },
+    {
+      "cardName": "Loth-cat",
+      "customInstructions": ""
+    },
+    {
+      "cardName": "Probe Droid",
+      "customInstructions": ""
+    },
+    {
+      "cardName": "Probe Droid",
+      "customInstructions": ""
+    }
+  ]
+}

--- a/ImperialCommander2/Assets/Resources/Languages/Fr/Missions/Other/OTHER15_FR.json
+++ b/ImperialCommander2/Assets/Resources/Languages/Fr/Missions/Other/OTHER15_FR.json
@@ -1,0 +1,932 @@
+{
+  "languageID": "French (FR)",
+  "missionProperties": {
+    "missionName": "Abus de l'exécutif",
+    "missionDescription": "Les héros doivent emmener un allié Spectre dans cette mission. Si les héros n'ont pas gagné d'allié Spectre, ils gagnent un allié Spectre de leur choix pour cette mission uniquement. ==== L'Empire a renforcé son emprise sur Lothal. Un officier, le colonel Xarok, s'est rendu célèbre pour ses pratiques brutales. Un agent local doit vous rencontrer pour lui faire passer un message : la Rébellion ne laissera pas cette situation s'éterniser.",
+    "missionInfo": "",
+    "campaignName": "Extension \"Ezra Bridger et Kanan Jarrus\"",
+    "startingObjective": "",
+    "repositionOverride": "Bloquer l'accès aux portes.",
+    "additionalMissionInfo": "Les héros doivent emmener un allié Spectre dans cette mission. Si les héros n'ont pas gagné d'allié Spectre, ils gagnent un allié Spectre de leur choix pour cette mission uniquement."
+  },
+  "events": [
+    {
+      "eventName": "Open Crate 1",
+      "GUID": "2dec36b9-ce77-4bf6-8c35-9489e6573609",
+      "eventText": "Vous fouillez la caisse et prenez ce qui vous semble utile.\r\n\r\nPiochez une carte Ravitaillement. Vous gagnez 1 médipack. Récupérez ce pion.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Crate1",
+              "GUID": "47376865-426b-469c-a52f-ce98917c1451",
+              "theText": "Une vieille caisse de ravitaillement.",
+              "buttonList": [
+                {
+                  "GUID": "69ce4b10-ef7c-40f2-9a67-65664cd72e3f",
+                  "theText": "{A} Ouvrir"
+                }
+              ]
+            }
+          ],
+          "GUID": "8eb6c4bb-fd64-4ae8-9b6d-a5ba3f737e6a",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "Open Crate 2",
+      "GUID": "74bbaee9-47db-48c2-b09c-7d0940adf6ab",
+      "eventText": "Vous fouillez la caisse et prenez ce qui vous semble utile.\r\n\r\nPiochez une carte Ravitaillement. Vous gagnez 1 médipack. Récupérez ce pion.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Crate2",
+              "GUID": "5d8754e8-5c4e-4fc5-96a6-e7932922eaa8",
+              "theText": "Une vieille caisse de ravitaillement.",
+              "buttonList": []
+            }
+          ],
+          "GUID": "a6f06d59-b18c-465a-acc1-85db4a122e25",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "Open Crate 3",
+      "GUID": "4c60aea9-45d0-4dbe-9bea-27d51eba9079",
+      "eventText": "Vous fouillez la caisse et prenez ce qui vous semble utile.\r\n\r\nPiochez une carte Ravitaillement. Vous gagnez 1 médipack. Récupérez ce pion.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Crate3",
+              "GUID": "def8c56e-ed27-43e5-bf92-fd2cf0834c73",
+              "theText": "Une vieille caisse de ravitaillement.",
+              "buttonList": []
+            }
+          ],
+          "GUID": "50b5bf42-216f-45db-925e-d733f34fdd76",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "Mission Briefing",
+      "GUID": "edc56ae0-7e4f-4ecd-9176-26e69bfd835a",
+      "eventText": "Vous entrez dans la cantina dont le tyrannique colonel Xarok fait régulièrement son Q.G., bien décidés à faire un exemple de ce monstre.\r\n\r\n{-} Déployez les héros sur la case bleue en surbrillance.\r\n{-} Les portes sont verrouillées.",
+      "eventActions": [
+        {
+          "tbText": "Deux des lieutenants de Xarok tournent immédiatement leur attention vers vous.",
+          "GUID": "2f4ffbc4-af99-4278-8f61-d7baf5d678ac",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "enemyName": "Lieutenant de Xarok (Officier Impérial)",
+          "customText": "",
+          "modification": "+*1* Santé",
+          "repositionInstructions": "",
+          "GUID": "4c051cc6-9e17-4673-a88a-08ca3a320e4c",
+          "eventActionType": 6,
+          "eaName": "Deploy: DG004/Imperial Officer"
+        },
+        {
+          "enemyName": "Lieutenant de Xarok (Officier Impérial)",
+          "customText": "",
+          "modification": "+*1* Santé",
+          "repositionInstructions": "",
+          "GUID": "4d34ccc2-5f42-40c7-b439-e984207a1f4e",
+          "eventActionType": 6,
+          "eaName": "Deploy: DG005/Imperial Officer"
+        },
+        {
+          "tbText": "Les lieutenants doivent porter le code jusqu'à la porte. Vous préparez vos armes.\r\n\r\n{-} Quand les deux Officiers Impériaux sont vaincus, la porte du marché se déverrouille.\r\n{-} La mission évolue quand la porte du marché s'ouvre.\r\n{-} Les Rebelles perdent quand tous les héros sont blessés.",
+          "GUID": "92a08eb0-63d1-457c-88f9-2e5a8f072168",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "shortText": "Vaincre les deux lieutenants (&Officers defeated&/2).",
+          "longText": null,
+          "GUID": "b797777e-cc9f-4929-a78a-ffb19265fc7f",
+          "eventActionType": 2,
+          "eaName": "Change Objective"
+        },
+        {
+          "theText": "{-} Les portes sont verrouillées. Quand les deux Officiers Impériaux sont vaincus, la porte du marché se déverrouille.\r\n{-} La mission évolue quand la porte du marché s'ouvre.\r\n{-} Les Rebelles perdent quand tous les héros sont blessés.",
+          "GUID": "e9c7060c-7b14-49ea-9357-3372b567b174",
+          "eventActionType": 1,
+          "eaName": "Change Mission Info"
+        }
+      ]
+    },
+    {
+      "eventName": "End of Mission - Rebels win",
+      "GUID": "69b80fad-5e0e-46cd-a70e-defa45de4db6",
+      "eventText": "Vous assommez Xarok à coups de poing et le ligotez dans le bureau. Malgré ses supplications, vous le laissez à la merci des habitants.\r\n\r\n{-} Les Rebelles remportent la mission !\r\n{-} S'il s'agit d'une mission annexe, les héros reçoivent 1 allié Spectre de leur choix en tant qu'allié.",
+      "eventActions": [
+        {
+          "mainText": "Jouez-vous cette mission dans le cadre de la mini-campagne \"Tyrans de Lothal\" ?",
+          "buttonList": [
+            {
+              "GUID": "67eeae33-2f73-4c13-b09d-9124c2120b0e",
+              "theText": "Oui"
+            },
+            {
+              "GUID": "9c2570cd-3b07-44d6-b9fa-b8c6e506596f",
+              "theText": "Non"
+            }
+          ],
+          "GUID": "fa160c96-ff1c-4306-ad5f-f40d51ef9331",
+          "eventActionType": 5,
+          "eaName": "Question Prompt"
+        }
+      ]
+    },
+    {
+      "eventName": "End of Mission - Rebels lose",
+      "GUID": "9e960fce-d271-468c-8d6c-233bc752aa52",
+      "eventText": "Xarok et ses gardes vous submergent, et vous n'avez d'autre choix que de vous replier. Comme vous vous enfuyez, vous voyez les hommes de Xarok tabasser et arrêter des habitants pour vous faire payer vos crimes.\r\n\r\n{-} Les Rebelles perdent la mission.",
+      "eventActions": [
+        {
+          "mainText": "Jouez-vous cette mission dans le cadre de la mini-campagne \"Tyrans de Lothal\" ?",
+          "buttonList": [
+            {
+              "GUID": "91d9a6f0-827a-408f-9184-becd00195eaa",
+              "theText": "Oui"
+            },
+            {
+              "GUID": "998960a0-bee5-4079-a22f-b849faf91b35",
+              "theText": "Non"
+            }
+          ],
+          "GUID": "922d0b18-3b9c-4426-b8b1-9d79afd7d873",
+          "eventActionType": 5,
+          "eaName": "Question Prompt"
+        }
+      ]
+    },
+    {
+      "eventName": "Mini campaign Win",
+      "GUID": "1fb0c0b1-7388-42f6-9c4c-801de27f03a5",
+      "eventText": "Peu après votre départ, N-4M vous parle de l'ancien fief de Xarok : les forces Impériales ont tenté d'en reprendre le contrôle, mais ont rencontré une certaine résistance.\r\n\r\n\"Ce sont de braves gens\", dit Ezra lorsque vous regagnez le Ghost. \"Ils en ont marre de l'Empire. Ils ne laisseront pas Thrawn leur marcher sur les pieds.\"\r\n\r\n\"Et Thrawn recevra le message qu'on lui a fait passer\", dit Kanan. \"On est toujours dans la course, et il ne pourra pas nous arrêter.\"\r\n\r\n{-} Chaque héros reçoit 1 XP.\r\n{-} Les héros reçoivent 200 crédits par héros.",
+      "eventActions": [
+        {
+          "tbText": "À bord du Ghost, vous trouvez Hera et Sabine en train d'étudier les restes d'un droïde infiltrateur E-XD. Nous nous sommes aperçues que plusieurs de ces choses tentaient de nous suivre dernièrement\", commenta Hera. \"Et Thrawn n'a pas encore abandonné. Nous devons jouer à armes égales.\"\r\n\r\n\"Alors, donnons-lui d'autres sujets d'inquiétudes\", suggéra Sabine. \"Même si cela ne mobilise que quelques stormtroopers. Nous ne sommes pas restés suffisamment longtemps sur Géonosis pour que je puisse m'en assurer, mais je pense que nous pourrions être capables de remettre en marche une partie de ces vieux droïdes de combat.\"\r\n\r\n\"Ou\", intervint Hera, \"nous pouvons essayer d'aider les rebelles Twi'lek sur Ryloth. L'Empire a intercepté leurs équipements depuis un moment maintenant. Si nous pouvons les aider à revenir dans la lutte, Thrawn aura une nouvelle épine dans le pied.\"\r\n\r\n{-} Les héros choisissent collectivement s'ils souhaitent inspecter l'usine de droïdes ou porter assistance aux rebelles Twi'lek.\r\n{-} Si les héros choisissent d'inspecter l'usine de droïdes, la prochaine mission active est \"État de siège sur Géonosis\".\r\n{-} Si les héros choisissent de porter assistance aux rebelles Twi'lek, la prochaine mission active est \"Course de vitesse sur Ryloth\".",
+          "GUID": "70297cc7-1998-4869-9593-2a516352352b",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        }
+      ]
+    },
+    {
+      "eventName": "Mini campaign Defeat",
+      "GUID": "ee9e6f21-9b9f-47ca-b982-44b59453a837",
+      "eventText": "N-4M vous informe que les représailles de Xarok se sont intensifiées : il fait preuve d'une poigne de fer. Ezra est déçu de l'apprendre. \"Ce sont de braves gens, ils ne méritent pas ça.\"\r\n\r\n\"Personne ne le mérite\", dit Kanan en lui posant la main sur l'épaule. \"Voilà pourquoi nous ne cesserons pas le combat. Gagnée ou perdue, toute bataille est une étincelle capable de déclencher un brasier. Nous prouvons au peuple que la rébellion est possible.\"\r\n\r\n\"Dans ce cas, assurons-nous que la Rébellion survive assez longtemps pour qu'ils aient le temps de la rejoindre\", conclut Ezra.\r\n\r\n{-} Chaque héros reçoit 1 XP.\r\n{-} Les héros reçoivent 100 crédits par héros.",
+      "eventActions": [
+        {
+          "tbText": "À bord du Ghost, vous trouvez Hera et Sabine en train d'étudier les restes d'un droïde infiltrateur E-XD. Nous nous sommes aperçues que plusieurs de ces choses tentaient de nous suivre dernièrement\", commenta Hera. \"Et Thrawn n'a pas encore abandonné. Nous devons jouer à armes égales.\"\r\n\r\n\"Alors, donnons-lui d'autres sujets d'inquiétudes\", suggéra Sabine. \"Même si cela ne mobilise que quelques stormtroopers. Nous ne sommes pas restés suffisamment longtemps sur Géonosis pour que je puisse m'en assurer, mais je pense que nous pourrions être capables de remettre en marche une partie de ces vieux droïdes de combat.\"\r\n\r\n\"Ou\", intervint Hera, \"nous pouvons essayer d'aider les rebelles Twi'lek sur Ryloth. L'Empire a intercepté leurs équipements depuis un moment maintenant. Si nous pouvons les aider à revenir dans la lutte, Thrawn aura une nouvelle épine dans le pied.\"\r\n\r\n{-} Les héros choisissent collectivement s'ils souhaitent inspecter l'usine de droïdes ou porter assistance aux rebelles Twi'lek.\r\n{-} Si les héros choisissent d'inspecter l'usine de droïdes, la prochaine mission active est \"État de siège sur Géonosis\".\r\n{-} Si les héros choisissent de porter assistance aux rebelles Twi'lek, la prochaine mission active est \"Course de vitesse sur Ryloth\".",
+          "GUID": "47287281-1fab-4266-9d77-5cc0c3028fc9",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        }
+      ]
+    },
+    {
+      "eventName": "No campaign",
+      "GUID": "8fe1b24a-487b-46a0-9e81-94329508e0dc",
+      "eventText": "{-} Chaque héros reçoit 1 XP.\r\n{-} Les héros reçoivent 100 crédits par héros.",
+      "eventActions": []
+    },
+    {
+      "eventName": "Support Bystander 1",
+      "GUID": "0fdc59af-c3a0-4aca-8aa1-c2f56a3b83c8",
+      "eventText": "",
+      "eventActions": [
+        {
+          "mainText": "Vous discutez avec la danseuse Twi'lek, essayant de la rallier à votre cause.\r\n\r\n{-} Effectuez un test {J}. Appliquez +1 {B} au test pour chaque pion Stress présent sur la Twi'lek, puis défaussez ces pions Stress. Entrez le nombre de réussites ci-dessous.",
+          "failText": "",
+          "inputList": [
+            {
+              "GUID": "55983163-fb95-45b1-8ab6-ad17a1043583",
+              "theText": ""
+            }
+          ],
+          "GUID": "51192d65-2799-44d4-8483-bd54f7ba1ee8",
+          "eventActionType": 20,
+          "eaName": "Input Prompt"
+        }
+      ]
+    },
+    {
+      "eventName": "Bystander fail 1",
+      "GUID": "5120c926-1a40-42d3-9f8c-34787a958e28",
+      "eventText": "La Twi'lek secoue vigoureusement la tête. \"Je suis désolée. Xarok est un homme horrible, mais je dois penser à ma famille. Débrouillez-vous.\" Elle se précipite hors de la cantina.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Bystander 1",
+              "GUID": "b430cc6f-3fd7-404c-888c-04bd2f47a635",
+              "theText": "Une Twi'lek à la peau verte, vêtue d'une tenue de danseuse, observe l'affrontement les yeux écarquillés, ne sachant pas si elle doit ou non se dresser contre le tyran.\r\n\r\n{-} Un héros peut dépenser 1 point de déplacement lorsqu'il est sur la case de la Twi'lek ou sur une case adjacente pour tenter d'obtenir son soutien ({J}).",
+              "buttonList": [
+                {
+                  "GUID": "c77dbce2-0019-4c49-bbad-9c67bd5c809e",
+                  "theText": "Obtenir le soutien"
+                }
+              ]
+            }
+          ],
+          "GUID": "c1756912-4a30-42e0-a647-18128842492b",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "Bystander success 1",
+      "GUID": "cd5ef512-40f3-480b-9fe7-4d06f05d54a1",
+      "eventText": "La Twi'lek réfléchit un instant à vos paroles, puis acquiesce solennellement. \"Vous avez raison. Nous devons tous faire notre part. À bas Xarok !\" Elle saute de la piste de danse et commence à s'agripper à l'un des gardes.\r\n\r\n{-} Vous gagnez 1 {e}.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Bystander 1",
+              "GUID": "589c26ce-0e57-4c35-a8c4-b33eb892d776",
+              "theText": "La danseuse Twi'lek est aux prises avec quelques gardes, essayant de les occuper.",
+              "buttonList": []
+            }
+          ],
+          "GUID": "3e07b059-5bab-4b35-a49e-e329ce25a9f7",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "Support Bystander 2",
+      "GUID": "24100fb5-c565-4b43-9f33-ebcda3e9a7f2",
+      "eventText": "",
+      "eventActions": [
+        {
+          "mainText": "Vous parlez au barman Besalisk, essayant de le rallier à votre cause.\r\n\r\n{-} Effectuez un test {J}. Appliquez +1 {B} au test pour chaque pion Stress présent sur le Besalisk, puis défaussez ces pions Stress. Entrez le nombre de réussites ci-dessous.",
+          "failText": "",
+          "inputList": [
+            {
+              "GUID": "ee5d92e0-0d3c-4c50-ac28-a3eade001aca",
+              "theText": ""
+            }
+          ],
+          "GUID": "4baf8ac4-6834-43a6-9ae9-cff387aa4a8b",
+          "eventActionType": 20,
+          "eaName": "Input Prompt"
+        }
+      ]
+    },
+    {
+      "eventName": "Bystander fail 2",
+      "GUID": "d821bef7-d455-4d8c-ba8c-eb142ee602cb",
+      "eventText": "Le Besalisk grince des dents. \"Tu ne sais pas à quel point Xarok est fort !\", grogne-t-il, puis il ouvre une trappe vers la cave et disparaît sous terre.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Bystander 2",
+              "GUID": "b4adee0f-2097-46c8-92d6-f7b3a1745680",
+              "theText": "Le barman Besalisk est recroquevillé derrière le comptoir, ne sachant pas s'il doit ou non se dresser contre le tyran.\r\n\r\n{-} Un héros peut dépenser 1 point de déplacement lorsqu'il est sur la case du Besalisk ou sur une case adjacente pour tenter d'obtenir son soutien ({J}).",
+              "buttonList": [
+                {
+                  "GUID": "2b547ce7-4bcd-446c-90bf-074f5e3fdcb6",
+                  "theText": "Obtenir le soutien"
+                }
+              ]
+            }
+          ],
+          "GUID": "c93d5953-d175-4809-ab73-fc3775f631f6",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "Bystander success 2",
+      "GUID": "fc0846f0-9c69-4311-a6f9-9de931aa7799",
+      "eventText": "Le Besalisk hésite, puis tape du poing sur le comptoir. \"Vous avez raison ! Nous sommes restés silencieux trop longtemps ! C'est pour tous les gens que tu as opprimés, Xarok !\" Il s'empare de verres et de chopes et commence à les lancer sur les gardes.\r\n\r\n{-} Vous gagnez 1 {e}.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Bystander 2",
+              "GUID": "19b06dbd-996a-4824-918c-02356200edec",
+              "theText": "Le barman Besalisk bombarde les gardes de chopes et de verres qu'il lance à quatre mains.",
+              "buttonList": []
+            }
+          ],
+          "GUID": "83ac68d0-6aa7-48ea-b41a-c377720afeb7",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "Support Bystander 3",
+      "GUID": "6e2ee961-5179-4325-b645-080f4b9f542c",
+      "eventText": "",
+      "eventActions": [
+        {
+          "mainText": "Vous parlez à la videuse Dévaronienne, essayant de la rallier à votre cause.\r\n\r\n{-} Effectuez un test {J}. Appliquez +1 {B} au test pour chaque pion Stress présent sur la Dévaronienne, puis défaussez ces pions Stress. Entrez le nombre de réussites ci-dessous.",
+          "failText": "",
+          "inputList": [
+            {
+              "GUID": "287be08e-d127-4157-a277-da86b0c3c0d7",
+              "theText": ""
+            }
+          ],
+          "GUID": "3f4813b0-c28c-4c40-b05d-a17211a09f50",
+          "eventActionType": 20,
+          "eaName": "Input Prompt"
+        }
+      ]
+    },
+    {
+      "eventName": "Bystander fail 3",
+      "GUID": "9021515e-dc3c-487f-b4fb-b5f95154008f",
+      "eventText": "La Dévaronienne lève ses grandes mains. \"Non. Désolée. La vie avec Xarok n'est pas géniale, mais au moins c'est la vie. Je préfère attendre de voir qui en sortira vainqueur.\" Elle quitte rapidement le marché.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Bystander 3",
+              "GUID": "604a4af6-e3a4-4444-8748-b51ff18557a2",
+              "theText": "La videuse du marché, une grande femme Dévaronienne, se tient à l'écart du combat pour l'instant, ne sachant pas s'elle doit ou non s'opposer au tyran.\r\n\r\n{-} Un héros peut dépenser 1 point de déplacement lorsqu'il est sur la case de la Dévaronienne ou sur une case adjacente pour tenter d'obtenir son soutien ({J}).",
+              "buttonList": [
+                {
+                  "GUID": "33f7be67-8c25-46eb-bbe2-f8ccfefef07e",
+                  "theText": "Obtenir le soutien"
+                }
+              ]
+            }
+          ],
+          "GUID": "8eba1ade-d6cb-4b9b-9d0c-ec3a0134163a",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "Bystander success 3",
+      "GUID": "d38e248b-2c1a-45f4-a0bb-585ad0321f3f",
+      "eventText": "La Dévaronienne sourit, montrant des dents pointues. \"Ah, bien. Au moins, ça va être intéressant, non ? À bas les dictateurs !\" Elle se jette sur un garde, le plaquant au sol.\r\n\r\n{-} Vous gagnez 1 {e}.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Bystander 3",
+              "GUID": "e4c8b14d-dcb7-4d5d-84d0-44cc74feb917",
+              "theText": "La videuse Dévaronienne frappe les gardes à coups de poing.",
+              "buttonList": []
+            }
+          ],
+          "GUID": "c67ec705-9386-4aa1-8155-1449aed14a1f",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "Support Bystander 4",
+      "GUID": "fdc822ea-ca16-4929-9d70-d73c0256a4b0",
+      "eventText": "",
+      "eventActions": [
+        {
+          "mainText": "Vous parlez au marchand humain, essayant de le rallier à votre cause.\r\n\r\n{-} Effectuez un test {J}. Appliquez +1 {B} au test pour chaque pion Stress présent sur l'humain, puis défaussez ces pions Stress. Entrez le nombre de réussites ci-dessous.",
+          "failText": "",
+          "inputList": [
+            {
+              "GUID": "cc30bb69-b0fc-44b2-8a11-b2839255b90c",
+              "theText": ""
+            }
+          ],
+          "GUID": "308be456-8063-4f1a-8763-4d8d9f0b0359",
+          "eventActionType": 20,
+          "eaName": "Input Prompt"
+        }
+      ]
+    },
+    {
+      "eventName": "Bystander fail 4",
+      "GUID": "c9f41c0c-774e-4e1e-b9fb-142c4154b75c",
+      "eventText": "L'homme secoue la tête. Il reste silencieux pendant de longues secondes, puis dit simplement : \"Non\". Il s'esquive derrière son étal de marché.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Bystander 4",
+              "GUID": "327c781e-4826-4bff-902f-2bbad58acd3c",
+              "theText": "Un des commerçants du marché, un vieil homme, s'efforce de ne pas s'attirer d'ennuis, ne sachant pas s'il doit ou non se dresser contre le tyran.\r\n\r\n{-} Un héros peut dépenser 1 point de déplacement lorsqu'il est sur la case du vieil homme ou sur une case adjacente pour tenter d'obtenir son soutien ({J}).",
+              "buttonList": [
+                {
+                  "GUID": "a7125c1c-23b8-49c9-8793-5644367aa40d",
+                  "theText": "Obtenir le soutien"
+                }
+              ]
+            }
+          ],
+          "GUID": "2d30a8c2-0ea5-4cdd-b55e-f0ab21371bd5",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "Bystander success 4",
+      "GUID": "138f7ec3-ca52-4b98-8623-17d4a0fdf645",
+      "eventText": "Le vieil homme reste silencieux pendant de longues secondes, une expression triste passant sur son visage. Puis il serre les mains en poings. \"Cela a assez duré, n'est-ce pas ?\", dit-il doucement. Puis il tend soudain la jambe et fait trébucher l'un des gardes.\r\n\r\n{-} Vous gagnez 1 {e}.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Bystander 4",
+              "GUID": "b6608609-036f-4853-a524-f21381d25016",
+              "theText": "Le vieil homme fait de son mieux pour gêner les gardes.",
+              "buttonList": []
+            }
+          ],
+          "GUID": "be845913-a81c-49a2-8c56-096c7ea1b4ba",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "Unwelcome Visitors",
+      "GUID": "5fc7dde5-549c-4e7b-a1ec-89d350948c5e",
+      "eventText": "Alertée par le vacarme, une escouade de stormtroopers se précipite.",
+      "eventActions": [
+        {
+          "enemyName": null,
+          "customText": "",
+          "modification": null,
+          "repositionInstructions": "",
+          "GUID": "25f02b6d-0645-48a1-a647-1121e477172c",
+          "eventActionType": 6,
+          "eaName": "Deploy: DG001/Stormtrooper"
+        },
+        {
+          "tbText": "L'armure des soldats brille grâce à leurs nouvelles plaques.\r\n\r\n{-} Chaque figurine de ce groupe gagne 1 {g}.",
+          "GUID": "76d78fa9-2159-42ea-a615-4168ff36878a",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        }
+      ]
+    },
+    {
+      "eventName": "Market Door unlocks",
+      "GUID": "d467ef40-2398-477f-8533-e1963f777730",
+      "eventText": "Vous récupérez les cylindres codés des lieutenants.\r\n\r\n{-} La porte du Marché est maintenant déverrouillée.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Cantina Door",
+              "GUID": "1a082e07-5264-4eb6-8bbc-6a8e1ce10a52",
+              "theText": "La porte menant au marché couvert est déverrouillée.",
+              "buttonList": [
+                {
+                  "GUID": "50eb435d-e0f1-4447-84ad-a523f2c29837",
+                  "theText": "{A} Ouvrir"
+                }
+              ]
+            }
+          ],
+          "GUID": "4a83db33-e1a3-41a7-8183-6d9f225604f1",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        },
+        {
+          "shortText": "Entrer dans le Marché.",
+          "longText": null,
+          "GUID": "f05589eb-6809-458a-91b7-f9d2722ebfea",
+          "eventActionType": 2,
+          "eaName": "Change Objective"
+        },
+        {
+          "theText": "{-} La mission évolue quand la porte du Marché s'ouvre.\r\n{-} Les Rebelles perdent quand tous les héros sont blessés.",
+          "GUID": "e293e23c-eb1c-49ef-8d77-0fc9e8dd6f3d",
+          "eventActionType": 1,
+          "eaName": "Change Mission Info"
+        }
+      ]
+    },
+    {
+      "eventName": "Let's Finish This",
+      "GUID": "7c9eedb8-13be-4bef-9084-90145b9b1bbd",
+      "eventText": "Vous ouvrez brutalement la porte et vous retrouvez face à face avec les gardes de Xarok dans le marché et la cantina.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Cantina Door",
+              "GUID": "8929d033-ad41-4f7f-b672-d87e44abf32c",
+              "theText": "La porte menant au marché couvert est fermement verrouillée.\r\n\r\n{-} Quand les deux Officiers Impériaux sont vaincus, la porte du marché se déverrouille.",
+              "buttonList": []
+            },
+            {
+              "entityName": "DP Green 1",
+              "GUID": "79292fbf-874e-418b-9460-74f0a829311f",
+              "theText": null,
+              "buttonList": []
+            },
+            {
+              "entityName": "DP Green 2",
+              "GUID": "1d12a1c5-ff89-4863-a798-86faf20fd099",
+              "theText": null,
+              "buttonList": []
+            },
+            {
+              "entityName": "DP Green 3",
+              "GUID": "5aed43da-ceae-4541-873f-055d55831c98",
+              "theText": null,
+              "buttonList": []
+            }
+          ],
+          "GUID": "cb6d5827-1d9f-4b48-9369-5bd7234b0350",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        },
+        {
+          "tbText": "Le tyran s'époumone dans le système comm, sans comprendre qu'il n'en a plus pour longtemps.",
+          "GUID": "2f454d03-5c4e-43b6-b660-447a1d5d9a33",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "enemyName": "Colonel Xarok (<color=\"red\">Officier Impérial</color>)",
+          "customText": "{A} Une autre figurine Impériale avec le coût le plus élevé et qui n'est pas <color=\"red\">Concentrée</color> devient <color=\"red\">Concentrée</color>.\r\n{A} ORDRE TYRANNIQUE : Choisir une autre figurine Impériale ayant le coût le plus élevé et qui peut attaquer, puis la faire attaquer {rebel}.",
+          "modification": null,
+          "repositionInstructions": "",
+          "GUID": "38cc0fe2-1328-482a-a2e5-154b186f099c",
+          "eventActionType": 6,
+          "eaName": "Deploy: DG006/Imperial Officer (Elite)"
+        },
+        {
+          "tbText": "Un soldat en armure noire semble avoir le code de la porte de l'arrière-salle.",
+          "GUID": "273a2aff-030f-4c43-ab64-4fc68c73966b",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "enemyName": "Garde de la Porte (<color=\"red\">Death Trooper</color>)",
+          "customText": "",
+          "modification": "+*1* Santé",
+          "repositionInstructions": "",
+          "GUID": "a5080384-6a6c-4c2e-b2a9-a6ca20b7ccaa",
+          "eventActionType": 6,
+          "eaName": "Deploy: DG058/Death Trooper (Elite)"
+        },
+        {
+          "tbText": "{-} La porte de l'Arrière-salle est verrouillée. Quand le Garde de la Porte (<color=\"red\">Death Trooper</color>) est vaincu, la porte se déverrouille.\r\n{-} La mission évolué quand la porte de l'Arrière-salle s'ouvre.\r\n{-} Les Rebelles perdent quand tous les héros sont blessés.",
+          "GUID": "f4e7621b-b7ff-4305-9711-1ceee8e03faa",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "tbText": "D'autres gardes du corps de Xarok sont rassemblés au marché et à la cantina.",
+          "GUID": "7f1ec946-7b55-4b79-938a-88da5185ca4a",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "tbText": "La plupart des gens s'enfuient lorsque vous faites irruption, mais quelques badauds restent, ne sachant pas s'ils doivent ou non se joindre au combat contre Xarok.",
+          "GUID": "de0f8f83-8ea3-4a41-8164-1faf0e3f065e",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Bystander 1",
+              "GUID": "c7f4dd1a-1241-4294-9473-31315ae088db",
+              "theText": "Une Twi'lek à la peau verte, vêtue d'une tenue de danseuse, observe l'affrontement les yeux écarquillés, ne sachant pas si elle doit ou non se dresser contre le tyran.\r\n\r\n{-} Un héros peut dépenser 1 point de déplacement lorsqu'il est sur la case de la Twi'lek ou sur une case adjacente pour tenter d'obtenir son soutien ({J}).",
+              "buttonList": [
+                {
+                  "GUID": "3859f700-20e4-47d9-91e9-34dacdf2668f",
+                  "theText": "Obtenir le soutien"
+                }
+              ]
+            },
+            {
+              "entityName": "Bystander 2",
+              "GUID": "c275d756-de5a-43c8-b61a-1cb0c6208184",
+              "theText": "Le barman Besalisk est recroquevillé derrière le comptoir, ne sachant pas s'il doit ou non se dresser contre le tyran.\r\n\r\n{-} Un héros peut dépenser 1 point de déplacement lorsqu'il est sur la case du Besalisk ou sur une case adjacente pour tenter d'obtenir son soutien ({J}).",
+              "buttonList": [
+                {
+                  "GUID": "a337834e-bd69-473c-bfc3-3a2a89ae9d6e",
+                  "theText": "Obtenir le soutien"
+                }
+              ]
+            },
+            {
+              "entityName": "Bystander 3",
+              "GUID": "9a61457c-5d9a-4b9f-b640-80018aa42619",
+              "theText": "La videuse du marché, une grande femme Dévaronienne, se tient à l'écart du combat pour l'instant, ne sachant pas s'elle doit ou non s'opposer au tyran.\r\n\r\n{-} Un héros peut dépenser 1 point de déplacement lorsqu'il est sur la case de la Dévaronienne ou sur une case adjacente pour tenter d'obtenir son soutien ({J}).",
+              "buttonList": [
+                {
+                  "GUID": "467d0439-2470-4ee3-92ee-f89ee0c113f4",
+                  "theText": "Obtenir le soutien"
+                }
+              ]
+            },
+            {
+              "entityName": "Bystander 4",
+              "GUID": "93b741e0-42fe-4977-9f3c-da94d089b132",
+              "theText": "Un des commerçants du marché, un vieil homme, s'efforce de ne pas s'attirer d'ennuis, ne sachant pas s'il doit ou non se dresser contre le tyran.\r\n\r\n{-} Un héros peut dépenser 1 point de déplacement lorsqu'il est sur la case du vieil homme ou sur une case adjacente pour tenter d'obtenir son soutien ({J}).",
+              "buttonList": [
+                {
+                  "GUID": "ea610dd4-08b9-4941-88a1-f040d9b4d04f",
+                  "theText": "Obtenir le soutien"
+                }
+              ]
+            }
+          ],
+          "GUID": "3e3e1eee-40e2-4716-9bf4-036c6595c425",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        },
+        {
+          "tbText": "{-} Les pions Mission neutres représentent des spectateurs. Un héros peut dépenser 1 point de déplacement lorsqu'il est sur la case d'un spectateurs ou sur une case adjacente pour tenter d'obtenir son soutien ({J}).",
+          "GUID": "e963e5d7-d847-4acb-a666-1362aa5048d1",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "shortText": "Vaincre le <color=\"red\">Death Trooper</color>.",
+          "longText": null,
+          "GUID": "3f499bc6-29a2-4a81-b3ab-9337187bc1d4",
+          "eventActionType": 2,
+          "eaName": "Change Objective"
+        },
+        {
+          "theText": "{-} Les pions Mission neutres représentent des spectateurs. Un héros peut dépenser 1 point de déplacement lorsqu'il est sur la case d'un spectateurs ou sur une case adjacente pour tenter d'obtenir son soutien ({J}).\r\n{-} La porte de l'Arrière-salle est verrouillée. Quand le Garde de la Porte (<color=\"red\">Death Trooper</color>) est vaincu, la porte se déverrouille.\r\n{-} La mission évolué quand la porte de l'Arrière-salle s'ouvre.\r\n{-} Les Rebelles perdent quand tous les héros sont blessés.",
+          "GUID": "76b7e871-2cd8-42e3-8a12-5f0ed353b77a",
+          "eventActionType": 1,
+          "eaName": "Change Mission Info"
+        }
+      ]
+    },
+    {
+      "eventName": "Back Room Door open",
+      "GUID": "d799de49-fd28-45b0-ab42-e3e5253e7938",
+      "eventText": "La porte de l'arrière-salles'ouvre. Le colonel Xarok est penché sur un micro, hurlant toujours des ordres et essayant de vous ignorer.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Back Room Door",
+              "GUID": "be6211ae-a734-4003-9adc-5053a70c62ec",
+              "theText": "Une porte solide mène à l'arrière-salle. Derrière la porte, on entend la voix furieuse de Xarok qui hurle des ordres.\r\n\r\n{-} La porte de l'Arrière-salle est verrouillée. Quand le (<color=\"red\">Death Trooper</color>) est vaincu, la porte se déverrouille.",
+              "buttonList": []
+            }
+          ],
+          "GUID": "07312cb3-98df-4c9a-8bb0-ef0db15078f2",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        },
+        {
+          "repositionText": null,
+          "GUID": "500b4276-317d-425f-81b4-4344b8d10504",
+          "eventActionType": 17,
+          "eaName": "Change Reposition Instructions"
+        },
+        {
+          "tbText": "Vous devez maîtriser Xarok, mais trop de brutalité enverrait un mauvais signal.\r\n\r\n{-} Une figurine Rebelle peut interagir avec Xarok ({K} ou {J}) pour que Xarok subisse 1 {H} pour chaque réussite. Durant ce test, cette figurine Rebelle peut subir 1 {C} pour relancer n'importe quel nombre de dés. Xarok ne peut pas éliminer de {H} et ne peut pas subir de {H} autrement que par cette interaction.",
+          "GUID": "f48efc9a-8a22-4977-9f4a-e7490f66cfd2",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "theText": "{-} Les pions Mission neutres représentent des spectateurs. Un héros peut dépenser 1 point de déplacement lorsqu'il est sur la case d'un spectateurs ou sur une case adjacente pour tenter d'obtenir son soutien ({J}).\r\n{-} Une figurine Rebelle peut interagir avec Xarok ({K} ou {J}) pour que Xarok subisse 1 {H} pour chaque réussite. Durant ce test, cette figurine Rebelle peut subir 1 {C} pour relancer n'importe quel nombre de dés. Xarok ne peut pas éliminer de {H} et ne peut pas subir de {H} autrement que par cette interaction.\r\n{-} Les Rebelles gagnent quand le colonel Xarok est vaincu.\r\n{-} Les Rebelles perdent quand tous les héros sont blessés.",
+          "GUID": "bd37ec6c-8f16-42ef-a8b8-ec42f9a1d4a4",
+          "eventActionType": 1,
+          "eaName": "Change Mission Info"
+        }
+      ]
+    },
+    {
+      "eventName": "Death Trooper defeated",
+      "GUID": "606e0d85-ac16-46cc-885e-fca7e1fba956",
+      "eventText": "Vous prenez le cylindre codé du Death Trooper vaincu.\r\n\r\n{-} La porte de l'Arrière-salle est maintenant déverrouillée.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Back Room Door",
+              "GUID": "4defc65e-4344-401f-933b-4fb3b800e106",
+              "theText": "Une porte solide mène à l'arrière-salle. Derrière la porte, on entend la voix furieuse de Xarok qui hurle des ordres.",
+              "buttonList": [
+                {
+                  "GUID": "63f85ece-d8a8-4978-bd60-43946871820b",
+                  "theText": "{A} Ouvrir"
+                }
+              ]
+            }
+          ],
+          "GUID": "c4ce4e2d-0976-41ae-929d-bf6e88fdf977",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        },
+        {
+          "shortText": "Vaincre le colonel Xarok.",
+          "longText": null,
+          "GUID": "c0693081-e5fc-4dfc-afa1-c67ccd6fe77f",
+          "eventActionType": 2,
+          "eaName": "Change Objective"
+        },
+        {
+          "theText": "{-} Les pions Mission neutres représentent des spectateurs. Un héros peut dépenser 1 point de déplacement lorsqu'il est sur la case d'un spectateurs ou sur une case adjacente pour tenter d'obtenir son soutien ({J}).\r\n{-} Les Rebelles gagnent quand le colonel Xarok est vaincu.\r\n{-} Les Rebelles perdent quand tous les héros sont blessés.",
+          "GUID": "5ef93f0e-a7fb-4b2a-a82b-0e592ecb5487",
+          "eventActionType": 1,
+          "eaName": "Change Mission Info"
+        }
+      ]
+    }
+  ],
+  "mapEntities": [
+    {
+      "entityName": "Crate1",
+      "GUID": "dcf1e03e-e328-4f79-8427-e0a0bfc64f82",
+      "mainText": "Une vieille caisse de ravitaillement.",
+      "buttonList": [
+        {
+          "GUID": "22a2fb35-cb6b-4d95-8a71-9cf55edb95a8",
+          "theText": "{A} Ouvrir"
+        }
+      ]
+    },
+    {
+      "entityName": "Crate2",
+      "GUID": "461e69e0-7c26-42a1-ad2a-a5e71b4f7707",
+      "mainText": "Une vieille caisse de ravitaillement.",
+      "buttonList": [
+        {
+          "GUID": "90135971-bff7-4e1d-8a36-2785d166bc00",
+          "theText": "{A} Ouvrir"
+        }
+      ]
+    },
+    {
+      "entityName": "Crate3",
+      "GUID": "1e60bee2-7e72-4f71-8c0e-45b5a2d0baf8",
+      "mainText": "Une vieille caisse de ravitaillement.",
+      "buttonList": [
+        {
+          "GUID": "fd123b12-9d45-4afa-826f-90a9bed011f9",
+          "theText": "{A} Ouvrir"
+        }
+      ]
+    },
+    {
+      "entityName": "Entrance",
+      "GUID": "a343a128-3b10-48ff-878f-71c89176d776",
+      "mainText": "Déployer les héros ici.",
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Green 1",
+      "GUID": "c8062d94-a52f-4458-b2cf-3c7b515747e5",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Green 2",
+      "GUID": "5bdffef2-c7c7-4e16-ab66-dca82b0481fd",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Green 3",
+      "GUID": "64b4dbf2-4e39-4ce7-a5fe-94eed25c16d2",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Officer 1",
+      "GUID": "81ead058-7663-414c-aed5-13a096cc71f9",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "Cantina Door",
+      "GUID": "d0baa93d-5323-4a5f-9e86-7f2e249e61aa",
+      "mainText": "La porte menant au marché couvert est fermement verrouillée.\r\n\r\n{-} Quand les deux Officiers Impériaux sont vaincus, la porte du marché se déverrouille.",
+      "buttonList": []
+    },
+    {
+      "entityName": "Back Room Door",
+      "GUID": "0a0c060d-083f-4e3d-9ff7-7642840af866",
+      "mainText": "Une porte solide mène à l'arrière-salle. Derrière la porte, on entend la voix furieuse de Xarok qui hurle des ordres.\r\n\r\n{-} La porte de l'Arrière-salle est verrouillée. Quand le (<color=\"red\">Death Trooper</color>) est vaincu, la porte se déverrouille.",
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Officer 2",
+      "GUID": "a3dd3dd2-8b20-40f4-bd1f-e584af9dda50",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Probe Droid",
+      "GUID": "d806f278-88b0-4df3-9574-609b6454c073",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Death Trooper",
+      "GUID": "3e3e0315-baa3-4e95-9eb1-4ba841105ec8",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Blue 1",
+      "GUID": "a2ab878c-79d9-43f3-9a6e-aa64a4eef7b2",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Blue 2",
+      "GUID": "cf90f3fa-de1d-4b9e-858c-73f2e5718255",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Yellow",
+      "GUID": "d486b2a6-0001-4a6b-9172-983eb7a7b671",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Red",
+      "GUID": "568e02f3-150d-4ba3-b34b-891317672d7e",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "Bystander 1",
+      "GUID": "9a8b8cd9-6f75-44dd-a3eb-f4d66f0110e2",
+      "mainText": "Une Twi'lek à la peau verte, vêtue d'une tenue de danseuse, observe l'affrontement les yeux écarquillés, ne sachant pas si elle doit ou non se dresser contre le tyran.\r\n\r\n{-} Un héros peut dépenser 1 point de déplacement lorsqu'il est sur la case de la Twi'lek ou sur une case adjacente pour tenter d'obtenir son soutien ({J}).",
+      "buttonList": [
+        {
+          "GUID": "18a9c14d-f8b1-4d5f-b8aa-39ee746f904f",
+          "theText": "Obtenir le soutien"
+        }
+      ]
+    },
+    {
+      "entityName": "Bystander 2",
+      "GUID": "b86a3b9b-1863-4b58-b922-9f048837a029",
+      "mainText": "Le barman Besalisk est recroquevillé derrière le comptoir, ne sachant pas s'il doit ou non se dresser contre le tyran.\r\n\r\n{-} Un héros peut dépenser 1 point de déplacement lorsqu'il est sur la case du Besalisk ou sur une case adjacente pour tenter d'obtenir son soutien ({J}).",
+      "buttonList": [
+        {
+          "GUID": "5771e04d-9207-4cd1-ac26-bed16282194c",
+          "theText": "Obtenir le soutien"
+        }
+      ]
+    },
+    {
+      "entityName": "Bystander 3",
+      "GUID": "e853aebb-bae0-4207-b89a-d5da629c2a8b",
+      "mainText": "La videuse du marché, une grande femme Dévaronienne, se tient à l'écart du combat pour l'instant, ne sachant pas s'elle doit ou non s'opposer au tyran.\r\n\r\n{-} Un héros peut dépenser 1 point de déplacement lorsqu'il est sur la case de la Dévaronienne ou sur une case adjacente pour tenter d'obtenir son soutien ({J}).",
+      "buttonList": [
+        {
+          "GUID": "18124f31-1d6d-4c99-af76-8774cf8bf058",
+          "theText": "Obtenir le soutien"
+        }
+      ]
+    },
+    {
+      "entityName": "Bystander 4",
+      "GUID": "73108b97-d1b0-44f7-83ed-b705ef9121a1",
+      "mainText": "Un des commerçants du marché, un vieil homme, s'efforce de ne pas s'attirer d'ennuis, ne sachant pas s'il doit ou non se dresser contre le tyran.\r\n\r\n{-} Un héros peut dépenser 1 point de déplacement lorsqu'il est sur la case du vieil homme ou sur une case adjacente pour tenter d'obtenir son soutien ({J}).",
+      "buttonList": [
+        {
+          "GUID": "8a59176c-6bc6-4ba1-b85c-27df797af40c",
+          "theText": "Obtenir le soutien"
+        }
+      ]
+    }
+  ],
+  "initialGroups": [
+    {
+      "cardName": "Death Trooper",
+      "customInstructions": ""
+    },
+    {
+      "cardName": "Probe Droid",
+      "customInstructions": ""
+    }
+  ]
+}

--- a/ImperialCommander2/Assets/Resources/Languages/Fr/Missions/Other/OTHER23_FR.json
+++ b/ImperialCommander2/Assets/Resources/Languages/Fr/Missions/Other/OTHER23_FR.json
@@ -1,0 +1,915 @@
+{
+  "languageID": "French (FR)",
+  "missionProperties": {
+    "missionName": "Facteur d'intimidation",
+    "missionDescription": "Les héros doivent emmener un allié Spectre dans cette mission. Si les héros n'ont pas gagné d'allié Spectre, ils gagnent un allié Spectre de leur choix pour cette mission uniquement. ==== L'Empire a arrêté plusieurs Wookies qui s'étaient rebellés contre leurs maîtres. Il menace maintenant de s'en prendre à leurs familles s'ils ne leur donnent pas les noms des autres Wookies et des agents Rebelles qui les ont aidés. Un membre des Spectres doit venir pour vous aider à mettre ces familles à l'abri et ainsi empêcher l'Empire d'exercer cet odieux chantage.",
+    "missionInfo": "",
+    "campaignName": "Extension \"Sabine Wren et Zeb Orrelios\"",
+    "startingObjective": "",
+    "repositionOverride": "Bloquer l'accès à l'échelle de cordes.",
+    "additionalMissionInfo": "Les héros doivent emmener un allié Spectre dans cette mission. Si les héros n'ont pas gagné d'allié Spectre, ils gagnent un allié Spectre de leur choix pour cette mission uniquement."
+  },
+  "events": [
+    {
+      "eventName": "Open Crate 1",
+      "GUID": "2dec36b9-ce77-4bf6-8c35-9489e6573609",
+      "eventText": "Vous fouillez la caisse et prenez ce qui vous semble utile.\r\n\r\nPiochez une carte Ravitaillement. Vous gagnez 1 médipack. Récupérez ce pion.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Crate1",
+              "GUID": "0370478a-df6a-4366-b897-1c15a92c6ff6",
+              "theText": "Une vieille caisse de ravitaillement.",
+              "buttonList": [
+                {
+                  "GUID": "09abbb7f-6e33-4894-aa61-3d4349e8ff7f",
+                  "theText": "{A} Ouvrir"
+                }
+              ]
+            }
+          ],
+          "GUID": "8eb6c4bb-fd64-4ae8-9b6d-a5ba3f737e6a",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "Open Crate 2",
+      "GUID": "74bbaee9-47db-48c2-b09c-7d0940adf6ab",
+      "eventText": "Vous fouillez la caisse et prenez ce qui vous semble utile.\r\n\r\nPiochez une carte Ravitaillement. Vous gagnez 1 médipack. Récupérez ce pion.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Crate2",
+              "GUID": "a3357678-76b7-44a6-8bf6-e927e0221c39",
+              "theText": "Une vieille caisse de ravitaillement.",
+              "buttonList": []
+            }
+          ],
+          "GUID": "a6f06d59-b18c-465a-acc1-85db4a122e25",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "Open Crate 3",
+      "GUID": "4c60aea9-45d0-4dbe-9bea-27d51eba9079",
+      "eventText": "Vous fouillez la caisse et prenez ce qui vous semble utile.\r\n\r\nPiochez une carte Ravitaillement. Vous gagnez 1 médipack. Récupérez ce pion.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Crate3",
+              "GUID": "5f482960-7d18-4190-8671-10db918a0353",
+              "theText": "Une vieille caisse de ravitaillement.",
+              "buttonList": []
+            }
+          ],
+          "GUID": "50b5bf42-216f-45db-925e-d733f34fdd76",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "Mission Briefing",
+      "GUID": "edc56ae0-7e4f-4ecd-9176-26e69bfd835a",
+      "eventText": "Vous pataugez dans la jungle humide, impressionnés par les habitations arboricoles des Wookies. Tandis que vous arrivez en vue des coordonnées de l'avant-poste Impérial qui menace les familles des Wookies prisonniers, un cri et un tir de blaster vous ramènent à la réalité, et vous vous retournez pour faire face à vos assaillants.\r\n\r\n{-} Déployez les héros sur la case bleue en surbrillance.\r\n{-} Quand un héros se replie, il est neutralisé à la place. Quand il est activé, il ne reçoit que 1 action et ne peut utiliser cette action que pour effectuer un déplacement.",
+      "eventActions": [
+        {
+          "tbText": "Des échelles de corde relient les habitations arboricoles des Wookies au sol.",
+          "GUID": "e4a8b72e-bbd8-425a-b84d-51f40a3f413f",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Ladder South 1",
+              "GUID": "c5c951c9-2e5e-4c37-bf18-1178c70cc48d",
+              "theText": "Une échelle de corde permet d'accéder à l'une des habitations Wookies.\r\n\r\n{-} Les cases avec des échelles de cordes sont des terrains difficiles.\r\n{-} Quand une figurine Rebelle entre dans une case avec une échelle de cordes, cliquez sur l'échelle de cordes et sélectionnez \"Grimper\".",
+              "buttonList": [
+                {
+                  "GUID": "0f535132-7609-4859-b23a-99d951397594",
+                  "theText": "Grimper"
+                }
+              ]
+            },
+            {
+              "entityName": "Ladder South 2",
+              "GUID": "c5faa889-dd31-4c72-9293-f28265774a3b",
+              "theText": "Une échelle de corde permet d'accéder à l'une des habitations Wookies.\r\n\r\n{-} Les cases avec des échelles de cordes sont des terrains difficiles.\r\n{-} Quand une figurine Rebelle entre dans une case avec une échelle de cordes, cliquez sur l'échelle de cordes et sélectionnez \"Grimper\".",
+              "buttonList": [
+                {
+                  "GUID": "4ff90045-3f8d-45d3-a065-07ebbdd6a983",
+                  "theText": "Grimper"
+                }
+              ]
+            },
+            {
+              "entityName": "Ladder North 1",
+              "GUID": "eead3b0d-1424-4b37-bbd1-ae0da2691fb7",
+              "theText": "Une échelle de corde permet d'accéder à l'une des habitations Wookies.\r\n\r\n{-} Les cases avec des échelles de cordes sont des terrains difficiles.\r\n{-} Quand une figurine Rebelle entre dans une case avec une échelle de cordes, cliquez sur l'échelle de cordes et sélectionnez \"Grimper\".",
+              "buttonList": [
+                {
+                  "GUID": "cf7a5420-5c83-46ce-b674-a87595d0413f",
+                  "theText": "Grimper"
+                }
+              ]
+            },
+            {
+              "entityName": "Ladder North 2",
+              "GUID": "1d9e4ba0-f195-48f4-8549-b015321987ad",
+              "theText": "Une échelle de corde permet d'accéder à l'une des habitations Wookies.\r\n\r\n{-} Les cases avec des échelles de cordes sont des terrains difficiles.\r\n{-} Quand une figurine Rebelle entre dans une case avec une échelle de cordes, cliquez sur l'échelle de cordes et sélectionnez \"Grimper\".",
+              "buttonList": [
+                {
+                  "GUID": "ca7331a6-6824-4d3b-a520-5b34b0d54d18",
+                  "theText": "Grimper"
+                }
+              ]
+            }
+          ],
+          "GUID": "d495b189-902f-491c-a10b-d23ddf0de1f5",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        },
+        {
+          "tbText": "{-} Les pions Mission neutres représentent des échelles de cordes. Les cases avec des échelles de cordes sont des terrains difficiles.\r\n{-} Quand une figurine Rebelle entre dans une case avec une échelle de cordes, cliquez sur l'échelle de cordes et sélectionnez \"Grimper\".",
+          "GUID": "8417923f-0ca4-4a09-bf42-51e2bd57f3ce",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "tbText": "Vous commencez à vous diriger vers les habitations Wookies.\r\n\r\n{-} La mission évolue quand les Rebelles entrent dans les habitations dans les arbres.",
+          "GUID": "a1261529-368c-45ed-bdef-f7033ed471b2",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "shortText": "Entrer dans les habitations dans les arbres.",
+          "longText": null,
+          "GUID": "1298bc36-501e-47d7-9b1c-c1b938f24292",
+          "eventActionType": 2,
+          "eaName": "Change Objective"
+        },
+        {
+          "theText": "{-} Quand un héros se replie, il est neutralisé à la place. Quand il est activé, il ne reçoit que 1 action et ne peut utiliser cette action que pour effectuer un déplacement.\r\n{-} Les pions Mission neutres représentent des échelles de cordes. Les cases avec des échelles de cordes sont des terrains difficiles.\r\n{-} Quand une figurine Rebelle entre dans une case avec une échelle de cordes, cliquez sur l'échelle de cordes et sélectionnez \"Grimper\".\r\n{-} La mission évolue quand les Rebelles entrent dans les habitations dans les arbres.\r\n{-} Les Rebelles perdent quand tous les héros sont blessés.",
+          "GUID": "d3d8fb37-7722-4fe0-8dc6-b12da73b67be",
+          "eventActionType": 1,
+          "eaName": "Change Mission Info"
+        }
+      ]
+    },
+    {
+      "eventName": "End of Mission - Rebels win",
+      "GUID": "69b80fad-5e0e-46cd-a70e-defa45de4db6",
+      "eventText": "Une fois l'Empire chassé, les familles wookies vous invite à un rituel traditionnel de célébration. Vous vous hâtez de faire savoir que les familles des prisonniers sont en sécurité.\r\n\r\n{-} Les Rebelles remportent la mission !\r\n{-} S'il s'agit d'une mission annexe, les héros reçoivent 1 allié Spectre de leur choix en tant qu'allié.",
+      "eventActions": [
+        {
+          "mainText": "Jouez-vous cette mission dans le cadre de la mini-campagne \"Tyrans de Lothal\" ?",
+          "buttonList": [
+            {
+              "GUID": "f50f4780-f10b-4ba3-b33a-3d86cd41f272",
+              "theText": "Oui"
+            },
+            {
+              "GUID": "5331303e-78b4-4911-aca0-9064c9489673",
+              "theText": "Non"
+            }
+          ],
+          "GUID": "fa160c96-ff1c-4306-ad5f-f40d51ef9331",
+          "eventActionType": 5,
+          "eaName": "Question Prompt"
+        }
+      ]
+    },
+    {
+      "eventName": "End of Mission - Rebels lose",
+      "GUID": "9e960fce-d271-468c-8d6c-233bc752aa52",
+      "eventText": "Les déchargent de blaster vous sifflent aux oreilles et le nombre d'Impériaux ne cesse de gonfler. Vous êtes obligés d'abandonner la mission. Les prisonniers et leurs familles sont toujours en danger.\r\n\r\n{-} Les Rebelles perdent la mission.",
+      "eventActions": [
+        {
+          "mainText": "Jouez-vous cette mission dans le cadre de la mini-campagne \"Tyrans de Lothal\" ?",
+          "buttonList": [
+            {
+              "GUID": "57ff4014-a79a-438e-883e-3080f2af6b7d",
+              "theText": "Oui"
+            },
+            {
+              "GUID": "0deecd02-11a8-441a-9122-2b2384031816",
+              "theText": "Non"
+            }
+          ],
+          "GUID": "922d0b18-3b9c-4426-b8b1-9d79afd7d873",
+          "eventActionType": 5,
+          "eaName": "Question Prompt"
+        }
+      ]
+    },
+    {
+      "eventName": "Mini campaign Win",
+      "GUID": "1fb0c0b1-7388-42f6-9c4c-801de27f03a5",
+      "eventText": "\"Nos agents ont fait savoir aux prisonniers wookies que leurs familles étaient en sécurité\", vous annonce Hera lorsque vous rentrez de Kashyyyk.\r\n\r\n\"Ils ne diront plus rien à l'Empire désormais\", ajoute-t-elle avant de vous dévisager. \"Les Wookies ont subi les pires exactions de la part de l'Empire. Voilà pourquoi nous nous battons.\"\r\n\r\n{-} Chaque héros reçoit 1 XP.\r\n{-} Les héros reçoivent 200 crédits par héros.",
+      "eventActions": [
+        {
+          "tbText": "À bord du Ghost, vous trouvez Hera et Sabine en train d'étudier les restes d'un droïde infiltrateur E-XD. Nous nous sommes aperçues que plusieurs de ces choses tentaient de nous suivre dernièrement\", commenta Hera. \"Et Thrawn n'a pas encore abandonné. Nous devons jouer à armes égales.\"\r\n\r\n\"Alors, donnons-lui d'autres sujets d'inquiétudes\", suggéra Sabine. \"Même si cela ne mobilise que quelques stormtroopers. Nous ne sommes pas restés suffisamment longtemps sur Géonosis pour que je puisse m'en assurer, mais je pense que nous pourrions être capables de remettre en marche une partie de ces vieux droïdes de combat.\"\r\n\r\n\"Ou\", intervint Hera, \"nous pouvons essayer d'aider les rebelles Twi'lek sur Ryloth. L'Empire a intercepté leurs équipements depuis un moment maintenant. Si nous pouvons les aider à revenir dans la lutte, Thrawn aura une nouvelle épine dans le pied.\"\r\n\r\n{-} Les héros choisissent collectivement s'ils souhaitent inspecter l'usine de droïdes ou porter assistance aux rebelles Twi'lek.\r\n{-} Si les héros choisissent d'inspecter l'usine de droïdes, la prochaine mission active est \"État de siège sur Géonosis\".\r\n{-} Si les héros choisissent de porter assistance aux rebelles Twi'lek, la prochaine mission active est \"Course de vitesse sur Ryloth\".",
+          "GUID": "b059bf49-c22c-44ea-b57e-682c2582028a",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        }
+      ]
+    },
+    {
+      "eventName": "Mini campaign Defeat",
+      "GUID": "ee9e6f21-9b9f-47ca-b982-44b59453a837",
+      "eventText": "Hera semble épuisée lorsque vous rejoignez le Ghost. \"Nous avons demandé à tous nos agents sur Kashyyyk de se cacher. Cela risque de retarder nos opérations dans le système de plusieurs mois, mais au moins seront-ils à l'abri si jamais les Wookies révèlent quoi que ce soit.\"\r\n\r\nBien qu'elle ne le dise pas, vous comprenez qu'Hera ne miserait pas trop sur leurs chances de s'en sortir. \"On ne peut pas gagner à tous les coups\", dit-elle enfin. \"Le principal est de gagner les batailles qui comptent.\"\r\n\r\n{-} Chaque héros reçoit 1 XP.\r\n{-} Les héros reçoivent 100 crédits par héros.",
+      "eventActions": [
+        {
+          "tbText": "À bord du Ghost, vous trouvez Hera et Sabine en train d'étudier les restes d'un droïde infiltrateur E-XD. Nous nous sommes aperçues que plusieurs de ces choses tentaient de nous suivre dernièrement\", commenta Hera. \"Et Thrawn n'a pas encore abandonné. Nous devons jouer à armes égales.\"\r\n\r\n\"Alors, donnons-lui d'autres sujets d'inquiétudes\", suggéra Sabine. \"Même si cela ne mobilise que quelques stormtroopers. Nous ne sommes pas restés suffisamment longtemps sur Géonosis pour que je puisse m'en assurer, mais je pense que nous pourrions être capables de remettre en marche une partie de ces vieux droïdes de combat.\"\r\n\r\n\"Ou\", intervint Hera, \"nous pouvons essayer d'aider les rebelles Twi'lek sur Ryloth. L'Empire a intercepté leurs équipements depuis un moment maintenant. Si nous pouvons les aider à revenir dans la lutte, Thrawn aura une nouvelle épine dans le pied.\"\r\n\r\n{-} Les héros choisissent collectivement s'ils souhaitent inspecter l'usine de droïdes ou porter assistance aux rebelles Twi'lek.\r\n{-} Si les héros choisissent d'inspecter l'usine de droïdes, la prochaine mission active est \"État de siège sur Géonosis\".\r\n{-} Si les héros choisissent de porter assistance aux rebelles Twi'lek, la prochaine mission active est \"Course de vitesse sur Ryloth\".",
+          "GUID": "ffc0d2ea-bfbd-4848-9656-da7215375277",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        }
+      ]
+    },
+    {
+      "eventName": "No campaign",
+      "GUID": "8fe1b24a-487b-46a0-9e81-94329508e0dc",
+      "eventText": "{-} Chaque héros reçoit 1 XP.\r\n{-} Les héros reçoivent 100 crédits par héros.",
+      "eventActions": []
+    },
+    {
+      "eventName": "Reveal Tree Houses",
+      "GUID": "23fc276a-82f6-4de8-a83d-a3cb970b0293",
+      "eventText": "Vous grimpez dans les hauteurs des arbres gigantesques de Kashyyyk. De là, vous pouvez bien voir les deux habitations dans les arbres.",
+      "eventActions": [
+        {
+          "tbText": "De vieilles caisses de ravitaillement contiennent quelques effets personnels de Wookie qui pourraient être utiles.",
+          "GUID": "f9ec079f-36a9-4654-a8de-4dbf1b1be3bb",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Ladder South 1",
+              "GUID": "bb9d8a30-0eaf-473c-896b-a7468ceff315",
+              "theText": "Une échelle de corde permet d'accéder à l'une des habitations Wookies.\r\n\r\n{-} Les cases avec des échelles de cordes sont des terrains difficiles.",
+              "buttonList": []
+            },
+            {
+              "entityName": "Ladder South 2",
+              "GUID": "80e6f3a2-284a-4e3e-a82d-7a36a5d3f849",
+              "theText": "Une échelle de corde permet d'accéder à l'une des habitations Wookies.\r\n\r\n{-} Les cases avec des échelles de cordes sont des terrains difficiles.",
+              "buttonList": []
+            },
+            {
+              "entityName": "Crate3",
+              "GUID": "ea953b9b-307a-4e43-b61d-d0e8320abdc1",
+              "theText": "Une vieille caisse de ravitaillement.",
+              "buttonList": [
+                {
+                  "GUID": "258062c6-4356-40fa-a478-2cd5f0cf598b",
+                  "theText": "{A} Ouvrir"
+                }
+              ]
+            },
+            {
+              "entityName": "Crate2",
+              "GUID": "a3aefe12-3262-42d8-9d9a-31f20d77beae",
+              "theText": "Une vieille caisse de ravitaillement.",
+              "buttonList": [
+                {
+                  "GUID": "0f54d031-5b0a-4731-ba76-fa5e773baa85",
+                  "theText": "{A} Ouvrir"
+                }
+              ]
+            },
+            {
+              "entityName": "Ladder North 1",
+              "GUID": "c47e0f47-a159-40eb-a017-c1a2e4cfcfe9",
+              "theText": "Une échelle de corde permet d'accéder à l'une des habitations Wookies.\r\n\r\n{-} Les cases avec des échelles de cordes sont des terrains difficiles.",
+              "buttonList": []
+            },
+            {
+              "entityName": "Ladder North 2",
+              "GUID": "59ae996b-aaf9-4278-a5d2-8657a446cddc",
+              "theText": "Une échelle de corde permet d'accéder à l'une des habitations Wookies.\r\n\r\n{-} Les cases avec des échelles de cordes sont des terrains difficiles.",
+              "buttonList": []
+            }
+          ],
+          "GUID": "8dff7793-6730-42f3-a8df-7f01975a2061",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        },
+        {
+          "tbText": "Comme vous l'espériez, les membres des familles des Wookies prisonniers se trouvent dans les habitations.",
+          "GUID": "15fc7425-00c6-40b2-a004-8849805f1f19",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Wookiee South 1",
+              "GUID": "312f7c34-4321-4fed-bdd7-606e65935074",
+              "theText": "Ifruhrr, le jeune cousin d'un des Wookies prisonniers, se cache ici, dans le coin.\r\n\r\n{-} Une figurine Rebelle adjacente à Ifruhrr peut dépenser 2 points de déplacement pour le secourir (et s'approprier son pion).",
+              "buttonList": [
+                {
+                  "GUID": "9f5e9f24-6cea-46d0-a056-19983fd566f8",
+                  "theText": "Secourir"
+                }
+              ]
+            },
+            {
+              "entityName": "Wookiee South 2",
+              "GUID": "4d565cff-364b-4146-9050-949da17a7967",
+              "theText": "Trraschirr, un artisan Wookie, serre les poings et hurle contre les impériaux, impuissant.\r\n\r\n{-} Une figurine Rebelle adjacente à Trraschirr peut dépenser 2 points de déplacement pour le secourir (et s'approprier son pion).",
+              "buttonList": [
+                {
+                  "GUID": "6c0d56b2-c6fb-4e5b-94d4-9d9ad08de0d0",
+                  "theText": "Secourir"
+                }
+              ]
+            },
+            {
+              "entityName": "Wookiee North 1",
+              "GUID": "dfb268df-8e2c-400f-9ff0-3a7cc712893e",
+              "theText": "Rerrrercu, la vieille grand-mère à la fourrure grise de l'un des Wookies prisonniers, cligne des yeux.\r\n\r\n{-} Une figurine Rebelle adjacente à Rerrrercu peut dépenser 2 points de déplacement pour la secourir (et s'approprier son pion).",
+              "buttonList": [
+                {
+                  "GUID": "cc1ba4f6-57a5-418b-b140-def83699e5b7",
+                  "theText": "Secourir"
+                }
+              ]
+            },
+            {
+              "entityName": "Wookiee North 2",
+              "GUID": "0139dd07-cc5d-46b8-944c-c29e05324a00",
+              "theText": "Morrsoobhe, une féroce guerrière Wookie, grogne contre les Impériaux, incapable de briser les liens qui l'attachent.\r\n\r\n{-} Une figurine Rebelle adjacente à Morrsoobhe peut dépenser 2 points de déplacement pour la secourir (et s'approprier son pion).",
+              "buttonList": [
+                {
+                  "GUID": "5325d0b2-3d54-4cb8-b2b2-11b728a2aab3",
+                  "theText": "Secourir"
+                }
+              ]
+            }
+          ],
+          "GUID": "8663d2cf-060d-48fc-aa9a-8c14696113fe",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        },
+        {
+          "tbText": "{-} Les pions Mission Rebelles représentent des Wookies. Une figurine Rebelle adjacente à un Wookie peut dépenser 2 points de déplacement pour le secourir (et s'approprier son pion).\r\n{-} Quand les 4 Wookies ont été secourus et que tous les héros sont dans la Zone d'extraction (cases vertes en surbrillance), les héros sont extraits.\r\n{-} Les Rebelles gagnent quand les héros sont extraits.\r\n{-} Les Rebelles perdent quand tous les héros sont blessés.",
+          "GUID": "918ca051-c1c6-4952-b976-402ca360fd29",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Extraction Zone",
+              "GUID": "6a485aa3-2379-4569-9e29-66eced3d7a77",
+              "theText": "Ce sont les coordonnées que votre pilote vous a données pour votre extraction.\r\n\r\n{-} Quand les 4 Wookies ont été secourus et que tous les héros sont dans la Zone d'extraction (cases vertes en surbrillance), les héros sont extraits.",
+              "buttonList": []
+            }
+          ],
+          "GUID": "436185df-cafc-455c-81e7-f534de7d30fc",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        },
+        {
+          "repositionText": "Bloquer l'accès aux Wookies.",
+          "GUID": "798379f3-2dd1-42e7-a8b9-4b02143cb839",
+          "eventActionType": 17,
+          "eaName": "Change Reposition Instructions"
+        },
+        {
+          "shortText": "Secourir les Wookies (&Wookiees claimed&/4).",
+          "longText": null,
+          "GUID": "c4db58c6-dc42-4496-9ab3-f76b9ce26d5f",
+          "eventActionType": 2,
+          "eaName": "Change Objective"
+        },
+        {
+          "theText": "{-} Quand un héros se replie, il est neutralisé à la place. Quand il est activé, il ne reçoit que 1 action et ne peut utiliser cette action que pour effectuer un déplacement.\r\n{-} Les pions Mission neutres représentent des échelles de cordes. Les cases avec des échelles de cordes sont des terrains difficiles.\r\n{-} Les pions Mission Rebelles représentent des Wookies. Une figurine Rebelle adjacente à un Wookie peut dépenser 2 points de déplacement pour le secourir (et s'approprier son pion).\r\n{-} Quand les 4 Wookies ont été secourus et que tous les héros sont dans la Zone d'extraction (cases vertes en surbrillance), les héros sont extraits.\r\n{-} Les Rebelles gagnent quand les héros sont extraits.\r\n{-} Les Rebelles perdent quand tous les héros sont blessés.",
+          "GUID": "4d8dd785-3ec4-4ef3-913c-df800961c9c9",
+          "eventActionType": 1,
+          "eaName": "Change Mission Info"
+        }
+      ]
+    },
+    {
+      "eventName": "Reveal North",
+      "GUID": "1196b071-44f9-4870-90a7-7570be825ed0",
+      "eventText": "",
+      "eventActions": []
+    },
+    {
+      "eventName": "Overkill South E-Web",
+      "GUID": "528f72af-9966-4d91-a412-752e5ad7b303",
+      "eventText": "L'Empire a installé une terrifiante station d'artillerie dans la cabane, le canon pointé vers vous.",
+      "eventActions": [
+        {
+          "enemyName": null,
+          "customText": "",
+          "modification": null,
+          "repositionInstructions": "",
+          "GUID": "7d7f3298-a0a0-4c9c-8a9b-eb602db435b8",
+          "eventActionType": 6,
+          "eaName": "Deploy: DG008/E-Web Engineer (Elite)"
+        }
+      ]
+    },
+    {
+      "eventName": "Overkill North E-Web",
+      "GUID": "8ee7735b-27ef-4fc9-a1ae-24fbbdc6958a",
+      "eventText": "L'Empire a installé une terrifiante station d'artillerie dans la cabane, le canon pointé vers vous.",
+      "eventActions": [
+        {
+          "enemyName": null,
+          "customText": "",
+          "modification": null,
+          "repositionInstructions": "",
+          "GUID": "3e133f45-a35b-4af2-bb9a-487eee264ce2",
+          "eventActionType": 6,
+          "eaName": "Deploy: DG008/E-Web Engineer (Elite)"
+        }
+      ]
+    },
+    {
+      "eventName": "Claim Wookiee North 1",
+      "GUID": "0a9f4864-0b7d-410f-8bed-5d18d7aca56e",
+      "eventText": "Vous aidez Rerrrercu à se relever et pressez la vieille dame Wookie vers la sortie.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Wookiee North 1",
+              "GUID": "bcd7b5c7-a392-4aef-816f-fccbd5d992df",
+              "theText": "Rerrrercu, la vieille grand-mère à la fourrure grise de l'un des Wookies prisonniers, cligne des yeux.\r\n\r\n{-} Une figurine Rebelle adjacente à Rerrrercu peut dépenser 2 points de déplacement pour la secourir (et s'approprier son pion).",
+              "buttonList": [
+                {
+                  "GUID": "84b947c3-36aa-47dc-95f7-80a54c9b2c9f",
+                  "theText": "Secourir"
+                }
+              ]
+            }
+          ],
+          "GUID": "a799ff14-d3df-4b03-8771-adb3df088f62",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "Claim Wookiee North 2",
+      "GUID": "47037d67-9dc4-4210-a191-adf2920f9a6c",
+      "eventText": "Vous crochetez rapidement la serrure des menottes de Morrsoobhe. La guerrière grogne et se précipite vers la sortie.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Wookiee North 2",
+              "GUID": "c41ada5d-760e-40fc-b191-df26713c9f1b",
+              "theText": "Morrsoobhe, une féroce guerrière Wookie, grogne contre les Impériaux, incapable de briser les liens qui l'attachent.\r\n\r\n{-} Une figurine Rebelle adjacente à Morrsoobhe peut dépenser 2 points de déplacement pour la secourir (et s'approprier son pion).",
+              "buttonList": [
+                {
+                  "GUID": "dd992961-1519-485e-aa8a-6d3154b485e5",
+                  "theText": "Secourir"
+                }
+              ]
+            }
+          ],
+          "GUID": "ed76f507-d5a6-48c5-9533-95dfcec99e2c",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "Claim Wookiee South 1",
+      "GUID": "44e9c544-11b5-44f0-9635-6efd0b5476cc",
+      "eventText": "Vous parlez calmement à Ifruhrr, qui acquiesce et se précipite ensuite vers la porte.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Wookiee South 1",
+              "GUID": "8518d6b9-7e0c-437e-ae6f-b6847cf10c07",
+              "theText": "Ifruhrr, le jeune cousin d'un des Wookies prisonniers, se cache ici, dans le coin.\r\n\r\n{-} Une figurine Rebelle adjacente à Ifruhrr peut dépenser 2 points de déplacement pour le secourir (et s'approprier son pion).",
+              "buttonList": [
+                {
+                  "GUID": "6b694f6c-4de9-483e-9cf4-da389c5f1053",
+                  "theText": "Secourir"
+                }
+              ]
+            }
+          ],
+          "GUID": "2be5a1f6-a953-48ba-840b-c95a480b5378",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "Claim Wookiee South 2",
+      "GUID": "a68b8d28-d2f5-4ad2-9c23-8995330f17a1",
+      "eventText": "Vous saisissez Trraschirr par le coude et l'emmenez rapidement vers la sortie.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Wookiee South 2",
+              "GUID": "f5bc8a96-4f35-48b2-a6bd-286f467c8d4f",
+              "theText": "Trraschirr, un artisan Wookie, serre les poings et hurle contre les impériaux, impuissant.\r\n\r\n{-} Une figurine Rebelle adjacente à Trraschirr peut dépenser 2 points de déplacement pour le secourir (et s'approprier son pion).",
+              "buttonList": [
+                {
+                  "GUID": "6f836d09-107a-4154-8335-e1fab2b204cd",
+                  "theText": "Secourir"
+                }
+              ]
+            }
+          ],
+          "GUID": "ae48f191-c80c-4f5c-b641-3cdf705525e3",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "Reveal South",
+      "GUID": "13829cd4-6250-48ad-9f1b-feb3b7885249",
+      "eventText": "Révéler le Sud",
+      "eventActions": []
+    },
+    {
+      "eventName": "Escape Route",
+      "GUID": "86f70f8d-cf11-4fee-9524-4fbb44161a29",
+      "eventText": "Le Wookie hurle de joie et de soulagement. Il vous dirige vers une série de cordes habilement dissimulées dans les arbres.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Bridge Blue 1",
+              "GUID": "3b15f487-9b20-4f61-924b-59867d032d02",
+              "theText": "Un pont de corde relie la cabane au sol.\r\n\r\n{-} Les pions Mission Impériaux représentent des ponts de cordes. Les figurines peuvent se déplacer entre des cases contenant des ponts de cordes de même couleur comme si ces cases étaient adjacentes.",
+              "buttonList": []
+            },
+            {
+              "entityName": "Bridge Blue 2",
+              "GUID": "a7447f41-1b1c-4db6-a142-e8dfd13be34e",
+              "theText": "Un pont de corde relie la cabane au sol.\r\n\r\n{-} Les pions Mission Impériaux représentent des ponts de cordes. Les figurines peuvent se déplacer entre des cases contenant des ponts de cordes de même couleur comme si ces cases étaient adjacentes.",
+              "buttonList": []
+            },
+            {
+              "entityName": "Bridge Red 1",
+              "GUID": "6961c7b6-0aca-46c4-a2bd-781ce1ae0519",
+              "theText": "Un pont de corde relie les deux cabanes.\r\n\r\n{-} Les pions Mission Impériaux représentent des ponts de cordes. Les figurines peuvent se déplacer entre des cases contenant des ponts de cordes de même couleur comme si ces cases étaient adjacentes.",
+              "buttonList": []
+            },
+            {
+              "entityName": "Bridge Red 2",
+              "GUID": "7fc495fe-1e58-46ef-9b66-4e1a8c9b2535",
+              "theText": "Un pont de corde relie les deux cabanes.\r\n\r\n{-} Les pions Mission Impériaux représentent des ponts de cordes. Les figurines peuvent se déplacer entre des cases contenant des ponts de cordes de même couleur comme si ces cases étaient adjacentes.",
+              "buttonList": []
+            }
+          ],
+          "GUID": "0a9fe7c1-fd48-4ba2-b5be-76e3088979e1",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        },
+        {
+          "tbText": "{-} Les pions Mission Impériaux représentent des ponts de cordes. Les figurines peuvent se déplacer entre des cases contenant des ponts de cordes de même couleur comme si ces cases étaient adjacentes.",
+          "GUID": "c830c30c-7907-4dfa-9dbc-f1f10e931de2",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "theText": "{-} Quand un héros se replie, il est neutralisé à la place. Quand il est activé, il ne reçoit que 1 action et ne peut utiliser cette action que pour effectuer un déplacement.\r\n{-} Les pions Mission neutres représentent des échelles de cordes. Les cases avec des échelles de cordes sont des terrains difficiles.\r\n{-} Les pions Mission Rebelles représentent des Wookies. Une figurine Rebelle adjacente à un Wookie peut dépenser 2 points de déplacement pour le secourir (et s'approprier son pion).\r\n{-} Les pions Mission Impériaux représentent des ponts de cordes. Les figurines peuvent se déplacer entre des cases contenant des ponts de cordes de même couleur comme si ces cases étaient adjacentes.\r\n{-} Quand les 4 Wookies ont été secourus et que tous les héros sont dans la Zone d'extraction (cases vertes en surbrillance), les héros sont extraits.\r\n{-} Les Rebelles gagnent quand les héros sont extraits.\r\n{-} Les Rebelles perdent quand tous les héros sont blessés.",
+          "GUID": "9183a71f-f140-41bc-be5a-13aeae76f25e",
+          "eventActionType": 1,
+          "eaName": "Change Mission Info"
+        }
+      ]
+    },
+    {
+      "eventName": "Imperial Thugs",
+      "GUID": "0ee8c595-6caf-46a5-b872-487193a41256",
+      "eventText": "D'autres forces impériales se précipitent pour vous empêcher de sauver les Wookies.",
+      "eventActions": []
+    },
+    {
+      "eventName": "Cut off",
+      "GUID": "08c7c4d8-0c72-4881-929e-ed1bfd9d150d",
+      "eventText": "Alors que vous commencez à vous diriger vers la zone d'extraction, vous apercevez un grand soldat en armure noire qui la garde.",
+      "eventActions": [
+        {
+          "enemyName": "Trooper Sentinelle (Death Trooper)",
+          "customText": "",
+          "modification": "+*1* Santé",
+          "repositionInstructions": "",
+          "GUID": "3ed41b6f-1f3c-431b-97fc-bfafe35f4966",
+          "eventActionType": 6,
+          "eaName": "Deploy: DG056/Death Trooper"
+        },
+        {
+          "tbText": "{-} Les héros ne peuvent pas être extraits tant que le Trooper Sentinelle est sur le plateau.",
+          "GUID": "630414a3-971f-48e7-b363-92e5cf57306b",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "repositionText": "Bloquer l'accès à la Zone d'extraction (cases vertes en surbrillance).",
+          "GUID": "a9ab9e2f-49de-4762-ac79-a759c2d442d9",
+          "eventActionType": 17,
+          "eaName": "Change Reposition Instructions"
+        },
+        {
+          "shortText": "Vaincre le Trooper Sentinelle.",
+          "longText": null,
+          "GUID": "790b0adf-fd54-4b42-aa70-c1d659236636",
+          "eventActionType": 2,
+          "eaName": "Change Objective"
+        },
+        {
+          "theText": "{-} Quand un héros se replie, il est neutralisé à la place. Quand il est activé, il ne reçoit que 1 action et ne peut utiliser cette action que pour effectuer un déplacement.\r\n{-} Les pions Mission neutres représentent des échelles de cordes. Les cases avec des échelles de cordes sont des terrains difficiles.\r\n{-} Les pions Mission Impériaux représentent des ponts de cordes. Les figurines peuvent se déplacer entre des cases contenant des ponts de cordes de même couleur comme si ces cases étaient adjacentes.\r\n{-} Les héros ne peuvent pas être extraits tant que le Trooper Sentinelle est sur le plateau.\r\n{-} Les Rebelles gagnent quand les héros sont extraits.\r\n{-} Les Rebelles perdent quand tous les héros sont blessés.",
+          "GUID": "245fc87e-6a09-4c09-a5e5-b9c9c399c7c4",
+          "eventActionType": 1,
+          "eaName": "Change Mission Info"
+        }
+      ]
+    },
+    {
+      "eventName": "Sentry Trooper defeated",
+      "GUID": "c885df4e-7164-47b6-9595-12034df92723",
+      "eventText": "La sentinelle étant partie, la voie de l'évasion est ouverte.\r\n\r\n{-} Quand tous les héros sont dans la zone d'extraction (cases vertes en surbrillance), les héros sont extraits. Cliquez sur la zone d'extraction et sélectionnez \"Extraction\".",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Extraction Zone",
+              "GUID": "ff8983d8-48f1-4ed1-99b2-c27bbf819d23",
+              "theText": "Ce sont les coordonnées que votre pilote vous a données pour votre extraction.\r\n\r\n{-} Quand tous les héros sont dans la zone d'extraction (cases vertes en surbrillance), les héros sont extraits. Cliquez sur la zone d'extraction et sélectionnez \"Extraction\".",
+              "buttonList": [
+                {
+                  "GUID": "50c18999-d911-4d36-a0fc-5b8c4a89c3de",
+                  "theText": "Extraction"
+                }
+              ]
+            }
+          ],
+          "GUID": "df565c4b-8aa2-4c89-8211-3be5e3ce1ce0",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        },
+        {
+          "shortText": "Partir !",
+          "longText": null,
+          "GUID": "79e3e99e-0b68-4c7d-a41f-65fc6b014fc2",
+          "eventActionType": 2,
+          "eaName": "Change Objective"
+        },
+        {
+          "theText": "{-} Quand un héros se replie, il est neutralisé à la place. Quand il est activé, il ne reçoit que 1 action et ne peut utiliser cette action que pour effectuer un déplacement.\r\n{-} Les pions Mission neutres représentent des échelles de cordes. Les cases avec des échelles de cordes sont des terrains difficiles.\r\n{-} Les pions Mission Impériaux représentent des ponts de cordes. Les figurines peuvent se déplacer entre des cases contenant des ponts de cordes de même couleur comme si ces cases étaient adjacentes.\r\n{-} Quand tous les héros sont dans la zone d'extraction (cases vertes en surbrillance), les héros sont extraits. Cliquez sur la zone d'extraction et sélectionnez \"Extraction\".\r\n{-} Les Rebelles gagnent quand les héros sont extraits.\r\n{-} Les Rebelles perdent quand tous les héros sont blessés.",
+          "GUID": "6bd0e362-de43-49c6-8a28-b32f1892c700",
+          "eventActionType": 1,
+          "eaName": "Change Mission Info"
+        }
+      ]
+    }
+  ],
+  "mapEntities": [
+    {
+      "entityName": "Crate1",
+      "GUID": "dcf1e03e-e328-4f79-8427-e0a0bfc64f82",
+      "mainText": "Une vieille caisse de ravitaillement.",
+      "buttonList": [
+        {
+          "GUID": "daabbb8c-0035-4102-8dd1-ab49e4e3d0eb",
+          "theText": "{A} Ouvrir"
+        }
+      ]
+    },
+    {
+      "entityName": "Crate2",
+      "GUID": "461e69e0-7c26-42a1-ad2a-a5e71b4f7707",
+      "mainText": "Une vieille caisse de ravitaillement.",
+      "buttonList": [
+        {
+          "GUID": "2e97db7b-1bee-494e-91ca-23ccbdf5e6bd",
+          "theText": "{A} Ouvrir"
+        }
+      ]
+    },
+    {
+      "entityName": "Crate3",
+      "GUID": "1e60bee2-7e72-4f71-8c0e-45b5a2d0baf8",
+      "mainText": "Une vieille caisse de ravitaillement.",
+      "buttonList": [
+        {
+          "GUID": "342fa7c3-22d5-4e7f-8fcc-4d206cccba1b",
+          "theText": "{A} Ouvrir"
+        }
+      ]
+    },
+    {
+      "entityName": "Entrance",
+      "GUID": "a343a128-3b10-48ff-878f-71c89176d776",
+      "mainText": "Déployer les héros ici.",
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Green 1",
+      "GUID": "c8062d94-a52f-4458-b2cf-3c7b515747e5",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Green 2",
+      "GUID": "5bdffef2-c7c7-4e16-ab66-dca82b0481fd",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Green 3",
+      "GUID": "64b4dbf2-4e39-4ce7-a5fe-94eed25c16d2",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Officer",
+      "GUID": "81ead058-7663-414c-aed5-13a096cc71f9",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Trando 1",
+      "GUID": "7155c3c3-4465-4e5f-a72d-ee4971e3a5b2",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Trando 2",
+      "GUID": "4560aaac-d27c-42a4-a51e-283becd1630f",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "Ladder South 1",
+      "GUID": "5faabef8-0da3-458e-983a-ddbc6daaddd3",
+      "mainText": "Une échelle de corde permet d'accéder à l'une des habitations Wookies.\r\n\r\n{-} Les cases avec des échelles de cordes sont des terrains difficiles.\r\n{-} Quand une figurine Rebelle entre dans une case avec une échelle de cordes, cliquez sur l'échelle de cordes et sélectionnez \"Grimper\".",
+      "buttonList": [
+        {
+          "GUID": "d7a8b60d-4a9e-4020-ad93-61ce18a89706",
+          "theText": "Grimper"
+        }
+      ]
+    },
+    {
+      "entityName": "Ladder South 2",
+      "GUID": "bafbbfa5-eac1-4762-8b55-8bda3dafdc35",
+      "mainText": "Une échelle de corde permet d'accéder à l'une des habitations Wookies.\r\n\r\n{-} Les cases avec des échelles de cordes sont des terrains difficiles.\r\n{-} Quand une figurine Rebelle entre dans une case avec une échelle de cordes, cliquez sur l'échelle de cordes et sélectionnez \"Grimper\".",
+      "buttonList": [
+        {
+          "GUID": "de1319ef-768a-480d-bb55-da17ce3d4b4d",
+          "theText": "Grimper"
+        }
+      ]
+    },
+    {
+      "entityName": "Ladder North 1",
+      "GUID": "92e7cace-b8d0-4f12-9da5-52f3776a129d",
+      "mainText": "Une échelle de corde permet d'accéder à l'une des habitations Wookies.\r\n\r\n{-} Les cases avec des échelles de cordes sont des terrains difficiles.\r\n{-} Quand une figurine Rebelle entre dans une case avec une échelle de cordes, cliquez sur l'échelle de cordes et sélectionnez \"Grimper\".",
+      "buttonList": [
+        {
+          "GUID": "6c754b85-46f6-4464-a504-9ac1c4734dce",
+          "theText": "Grimper"
+        }
+      ]
+    },
+    {
+      "entityName": "Ladder North 2",
+      "GUID": "fa4c6131-1559-4078-823a-af25044dfa18",
+      "mainText": "Une échelle de corde permet d'accéder à l'une des habitations Wookies.\r\n\r\n{-} Les cases avec des échelles de cordes sont des terrains difficiles.\r\n{-} Quand une figurine Rebelle entre dans une case avec une échelle de cordes, cliquez sur l'échelle de cordes et sélectionnez \"Grimper\".",
+      "buttonList": [
+        {
+          "GUID": "ced600e7-2764-4a26-80aa-8497af4b6502",
+          "theText": "Grimper"
+        }
+      ]
+    },
+    {
+      "entityName": "Bridge Blue 1",
+      "GUID": "b9d8d137-1932-4480-beb8-9845973375ab",
+      "mainText": "Un pont de corde relie la cabane au sol.\r\n\r\n{-} Les pions Mission Impériaux représentent des ponts de cordes. Les figurines peuvent se déplacer entre des cases contenant des ponts de cordes de même couleur comme si ces cases étaient adjacentes.",
+      "buttonList": []
+    },
+    {
+      "entityName": "Bridge Blue 2",
+      "GUID": "3538b0cc-78d7-4fa5-80c9-6def76660184",
+      "mainText": "Un pont de corde relie la cabane au sol.\r\n\r\n{-} Les pions Mission Impériaux représentent des ponts de cordes. Les figurines peuvent se déplacer entre des cases contenant des ponts de cordes de même couleur comme si ces cases étaient adjacentes.",
+      "buttonList": []
+    },
+    {
+      "entityName": "Bridge Red 1",
+      "GUID": "7be4d93b-a9a0-4fca-9528-34e2e910f086",
+      "mainText": "Un pont de corde relie la cabane au sol.\r\n\r\n{-} Les pions Mission Impériaux représentent des ponts de cordes. Les figurines peuvent se déplacer entre des cases contenant des ponts de cordes de même couleur comme si ces cases étaient adjacentes.",
+      "buttonList": []
+    },
+    {
+      "entityName": "Bridge Red 2",
+      "GUID": "164e4bd2-40a2-49cb-b196-634535ca4a3f",
+      "mainText": "Un pont de corde relie la cabane au sol.\r\n\r\n{-} Les pions Mission Impériaux représentent des ponts de cordes. Les figurines peuvent se déplacer entre des cases contenant des ponts de cordes de même couleur comme si ces cases étaient adjacentes.",
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Black",
+      "GUID": "20a7ea13-14f6-4fba-92ab-c6ba61284f23",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Extraction Zone",
+      "GUID": "b05235ca-c3f2-468e-baaa-c1ecfa979230",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Yellow North",
+      "GUID": "6f131639-c6d3-469e-8198-709982331435",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Yellow South",
+      "GUID": "dccb7f65-3535-4f8f-b535-8f6e7a24ae13",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "Wookiee North 1",
+      "GUID": "4c9b1c41-da69-4b68-8179-7334d2cac326",
+      "mainText": "Rerrrercu, la vieille grand-mère à la fourrure grise de l'un des Wookies prisonniers, cligne des yeux.\r\n\r\n{-} Une figurine Rebelle adjacente à Rerrrercu peut dépenser 2 points de déplacement pour la secourir (et s'approprier son pion).",
+      "buttonList": [
+        {
+          "GUID": "4c7e759c-3e8f-4eb9-9b89-802913de19c4",
+          "theText": "Secourir"
+        }
+      ]
+    },
+    {
+      "entityName": "Wookiee North 2",
+      "GUID": "f57879be-f8a9-45b8-a75f-68e60108fab5",
+      "mainText": "Morrsoobhe, une féroce guerrière Wookie, grogne contre les Impériaux, incapable de briser les liens qui l'attachent.\r\n\r\n{-} Une figurine Rebelle adjacente à Morrsoobhe peut dépenser 2 points de déplacement pour la secourir (et s'approprier son pion).",
+      "buttonList": [
+        {
+          "GUID": "f84bc2e0-98ee-459f-8eed-d7cc13e45050",
+          "theText": "Secourir"
+        }
+      ]
+    },
+    {
+      "entityName": "Wookiee South 1",
+      "GUID": "a94a0f9d-94ed-4660-af6f-4e202ea75205",
+      "mainText": "Ifruhrr, le jeune cousin d'un des Wookies prisonniers, se cache ici, dans le coin.\r\n\r\n{-} Une figurine Rebelle adjacente à Ifruhrr peut dépenser 2 points de déplacement pour le secourir (et s'approprier son pion).",
+      "buttonList": [
+        {
+          "GUID": "b2054f53-6cf8-4801-b048-0497b28fa661",
+          "theText": "Secourir"
+        }
+      ]
+    },
+    {
+      "entityName": "Wookiee South 2",
+      "GUID": "eea33645-d858-4a70-a6d5-f2176cf0c74c",
+      "mainText": "Trraschirr, un artisan Wookie, serre les poings et hurle contre les impériaux, impuissant.\r\n\r\n{-} Une figurine Rebelle adjacente à Trraschirr peut dépenser 2 points de déplacement pour le secourir (et s'approprier son pion).",
+      "buttonList": [
+        {
+          "GUID": "c7d86061-0f2a-40a8-b8ce-ac5e3d2b499e",
+          "theText": "Secourir"
+        }
+      ]
+    },
+    {
+      "entityName": "Extraction Zone",
+      "GUID": "86cd8f66-45c8-45d9-9aa0-10b6b38538a6",
+      "mainText": "Ce sont les coordonnées que votre pilote vous a données pour votre extraction.\r\n\r\n{-} Quand les 4 Wookies ont été secourus et que tous les héros sont dans la zone d'extraction (cases vertes en surbrillance), les héros sont extraits.",
+      "buttonList": []
+    }
+  ],
+  "initialGroups": [
+    {
+      "cardName": "Imperial Officer",
+      "customInstructions": ""
+    },
+    {
+      "cardName": "Trandoshan Hunter",
+      "customInstructions": ""
+    }
+  ]
+}

--- a/ImperialCommander2/Assets/Resources/Languages/Fr/Missions/Other/OTHER37_FR.json
+++ b/ImperialCommander2/Assets/Resources/Languages/Fr/Missions/Other/OTHER37_FR.json
@@ -1,0 +1,929 @@
+{
+  "languageID": "French (FR)",
+  "missionProperties": {
+    "missionName": "La poigne de l'amiral",
+    "missionDescription": "",
+    "missionInfo": "",
+    "campaignName": "Extension \"Thrawn (Grand Amiral)\"",
+    "startingObjective": "",
+    "repositionOverride": "Bloquer l'accès aux stations de sécurité.",
+    "additionalMissionInfo": ""
+  },
+  "events": [
+    {
+      "eventName": "Open Crate 1",
+      "GUID": "2dec36b9-ce77-4bf6-8c35-9489e6573609",
+      "eventText": "Vous fouillez la caisse et prenez ce qui vous semble utile.\r\n\r\nPiochez une carte Ravitaillement. Vous gagnez 1 médipack. Récupérez ce pion.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Crate1",
+              "GUID": "98e0369d-9cee-4c0a-8e0f-c2bd21bb1d48",
+              "theText": "Une vieille caisse de ravitaillement.",
+              "buttonList": [
+                {
+                  "GUID": "cd0b32bf-2ed7-4221-9815-a9a86a40903c",
+                  "theText": "{A} Ouvrir"
+                }
+              ]
+            }
+          ],
+          "GUID": "8eb6c4bb-fd64-4ae8-9b6d-a5ba3f737e6a",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "Open Crate 2",
+      "GUID": "74bbaee9-47db-48c2-b09c-7d0940adf6ab",
+      "eventText": "Vous fouillez la caisse et prenez ce qui vous semble utile.\r\n\r\nPiochez une carte Ravitaillement. Vous gagnez 1 médipack. Récupérez ce pion.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Crate2",
+              "GUID": "275f6569-a745-41ef-a94f-84de2fd047f1",
+              "theText": "Une vieille caisse de ravitaillement.",
+              "buttonList": []
+            }
+          ],
+          "GUID": "a6f06d59-b18c-465a-acc1-85db4a122e25",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "Mission Briefing",
+      "GUID": "edc56ae0-7e4f-4ecd-9176-26e69bfd835a",
+      "eventText": "Après avoir réussi à vous glisser à bord du Chimaera au moyen de codes volés, vous progressez avec précaution dans les coursives de l'énorme Star Destroyer. Arrivés à la porte du centre de traitement des droïdes espions, un Death Trooper se dresse en travers de votre chemin : \"Codes d'accès ?\"\r\n\r\nVotre hésitation est inacceptable et le trooper lève son fusil.\r\n\r\n{-} Déployez les héros sur la case bleue en surbrillance.\r\n{-} Les portes sont verrouillées.",
+      "eventActions": [
+        {
+          "tbText": "Plusieurs stations de sécurité contrôlent la serrure des portes.",
+          "GUID": "3281a72c-2028-4be2-a3f9-be0515f3684a",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Security Station 1",
+              "GUID": "678f3455-b090-4b81-997c-a3067375f5f1",
+              "theText": "La station de sécurité qui verrouille les portes est protégée par un épais placage.\r\n\r\n{-} Une figurine peut attaquer une station de sécurité (Santé : 2 plus *1*; Défense : 1 {G}).",
+              "buttonList": [
+                {
+                  "GUID": "7deefc5a-2178-4466-8ac0-d3f25e8fe47d",
+                  "theText": "Détruire"
+                }
+              ]
+            },
+            {
+              "entityName": "Security Station 2",
+              "GUID": "eff0d41e-35c1-49a7-8964-19209a27012f",
+              "theText": "La station de sécurité qui verrouille les portes est protégée par un épais placage.\r\n\r\n{-} Une figurine peut attaquer une station de sécurité (Santé : 2 plus *1*; Défense : 1 {G}).",
+              "buttonList": [
+                {
+                  "GUID": "38082311-232e-451e-bbbe-2799a5bc9d97",
+                  "theText": "Détruire"
+                }
+              ]
+            },
+            {
+              "entityName": "Security Station 3",
+              "GUID": "1787d5c5-22f9-4215-85c4-2d612ac1d820",
+              "theText": "La station de sécurité qui verrouille les portes est protégée par un épais placage.\r\n\r\n{-} Une figurine peut attaquer une station de sécurité (Santé : 2 plus *1*; Défense : 1 {G}).",
+              "buttonList": [
+                {
+                  "GUID": "88495f0f-0a24-4bdc-a8ba-508e959da31b",
+                  "theText": "Détruire"
+                }
+              ]
+            }
+          ],
+          "GUID": "17fa977f-de40-4678-aefb-b0c3edbceae7",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        },
+        {
+          "tbText": "{-} Les pions Mission Impériaux représentent des stations de sécurité. Une figurine peut attaquer une station de sécurité (Santé : 2 plus *1*; Défense : 1 {G}).\r\n{-} Quand les 3 stations de sécurité sont détruites, les portes se déverrouillent.",
+          "GUID": "5f4ac70f-868b-4bce-8880-75cf767d9707",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "shortText": "Détruire les stations de sécurité (&Stations destroyed&/3).",
+          "longText": null,
+          "GUID": "41cdb341-e423-482f-a452-7ac6bd7ebf1e",
+          "eventActionType": 2,
+          "eaName": "Change Objective"
+        },
+        {
+          "theText": "{-} Les portes sont verrouillées.\r\n{-} Les pions Mission Impériaux représentent des stations de sécurité. Une figurine peut attaquer une station de sécurité (Santé : 2 plus *1*; Défense : 1 {G}).\r\n{-} Quand les 3 stations de sécurité sont détruites, les portes se déverrouillent.\r\n{-} La mission évolue quand une porte s'ouvre.\r\n{-} Les Rebelles perdent quand tous les héros sont blessés.",
+          "GUID": "5fe5b0d0-fb8f-421a-a1c2-981796ba56da",
+          "eventActionType": 1,
+          "eaName": "Change Mission Info"
+        }
+      ]
+    },
+    {
+      "eventName": "End of Mission - Rebels win",
+      "GUID": "69b80fad-5e0e-46cd-a70e-defa45de4db6",
+      "eventText": "Vous quittez la pièce en trombe, en laissant derrière vous les terminaux en flammes et un Thrawn sous le choc. Vous transmettez les coordonnées du sas le plus proche à votre pilote et fuyez le courroux de l'Empire.\r\n\r\n{-} Les Rebelles remportent la mission !\r\n{-} Les héros reçoivent 100 crédits par héros.",
+      "eventActions": [
+        {
+          "mainText": "Jouez-vous cette mission dans le cadre de la mini-campagne \"Tyrans de Lothal\" ?",
+          "buttonList": [
+            {
+              "GUID": "316a0e10-378b-4518-966d-d067b06b1f9e",
+              "theText": "Oui"
+            },
+            {
+              "GUID": "14604c10-9a02-41f7-855e-a8430725cf8d",
+              "theText": "Non"
+            }
+          ],
+          "GUID": "fa160c96-ff1c-4306-ad5f-f40d51ef9331",
+          "eventActionType": 5,
+          "eaName": "Question Prompt"
+        }
+      ]
+    },
+    {
+      "eventName": "End of Mission - Rebels lose",
+      "GUID": "9e960fce-d271-468c-8d6c-233bc752aa52",
+      "eventText": "Les troupes de Thrawn vous encerclent et commencent à se rapprocher. Vous jetez une sacoche de grenades fumigènes à leurs pieds et filez en crachant vos poumons pour rejoindre la navette qui vous attend.\r\n\r\n{-} Les Rebelles perdent la mission.\r\n{-} Si vous jouez cette mission en tant que mission annexe, l'Empire reçoit <color=\"red\">Thrawn</color> (Grand Amiral) en tant qu'antagoniste.",
+      "eventActions": [
+        {
+          "mainText": "Jouez-vous cette mission dans le cadre de la mini-campagne \"Tyrans de Lothal\" ?",
+          "buttonList": [
+            {
+              "GUID": "01319e0f-ed6c-4f06-8680-375ca39e0820",
+              "theText": "Oui"
+            },
+            {
+              "GUID": "09e9ccd6-dfbe-47df-9f55-4762611818be",
+              "theText": "Non"
+            }
+          ],
+          "GUID": "922d0b18-3b9c-4426-b8b1-9d79afd7d873",
+          "eventActionType": 5,
+          "eaName": "Question Prompt"
+        }
+      ]
+    },
+    {
+      "eventName": "Mini campaign Win",
+      "GUID": "1fb0c0b1-7388-42f6-9c4c-801de27f03a5",
+      "eventText": "Vous vous installez à bord de votre vaisseau et passez en hyperespace, pourchassés par des TIE. L'appareil est secoué par les tirs du Chimaera avant que vous ne lui échappiez enfin.\r\n\r\n\"Même Thrawn ne pourra pas s'en remettre de sitôt. Il recevra des renforts, mais la récupération des données prendra du temps\", dit Sabine. \"J'aurais bien aimé voir ça. Ces terminaux de traitement devaient être terribles.\"\r\n\r\n\"Prenez quelques jours pour récupérer\", vous suggère Hera. \"Thrawn va vouloir vous retrouver. Et puis, vous l'avez bien mérité.\"\r\n\r\n{-} Chaque héros reçoit 1 XP.\r\n{-} Les héros reçoivent 100 crédits par héros.",
+      "eventActions": [
+        {
+          "tbText": "Un débat fait rage dans la salle commune du Ghost et vous l'entendez bien avant de le voir. \"Cela pourrait être notre meilleure chance de porter le combat sur le terrain de Thrawn\", insista Ezra tandis qu'il montrait une représentation holographique de Lothal et des nombreux destroyers stellaires qui gravitaient sur son orbite. \"Je sais que cela pourrait être un piège, mais si ce n'en était pas un ? Nous avons travaillé dur pour trouver une brèche qui nous permettrait de répondre aux attaques de Thrawn.\"\r\n\r\nVous les interrompez pour connaître l'objet de leur dispute.\r\n\r\n\"Un ingénieur Impérial nous a envoyé un message\", répond Kanan. \"Il veut déserter, et il prétend pouvoir nous introduire dans la chambre des données qui contient toutes les informations collectées par les droïdes d'infiltration de Thrawn.\" Lorsque le masque de Kanan se tourne dans votre direction, vous ne pouvez qu'imaginer son regard lourd de sens. \"Ces données lui donnent un avantage sur la Rébellion. Mais croire que quelqu'un nous laissera rentrer ? Cela semble trop beau pour être vrai.\"\r\n\r\n\"Nous n'aurons même pas l'occasion d'atterrir avec les gorilles de Thrawn partout dans les parages\", commente Zeb. \"Tous les Impériaux du secteur savent probablement à quoi nous ressemblons.\"\r\n\r\nVous faites un pas en avant. Les Spectres sont une pièce maîtresse de la Rébellion. Ils ne peuvent pas se permettre de prendre un tel risque. Mais vous, vous le pouvez.\r\n\r\n{-} La prochaine mission active est \"L'ordre final\".",
+          "GUID": "e173af91-b4cf-4ec7-9e4f-8087cbee2c8a",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        }
+      ]
+    },
+    {
+      "eventName": "Mini campaign Defeat",
+      "GUID": "ee9e6f21-9b9f-47ca-b982-44b59453a837",
+      "eventText": "À votre grand regret, N-4M transmet la nouvelle de votre défaite à Hera. Les espions de Thrawn ont sans doute des informations sur les opérations Rebelles dans le secteur. Pour leur sécurité, ces agents doivent évacuer.\r\n\r\nVous vous cachez pendant quelques jours, pendant que Thrawn cherche l'équipe qui a eu l'audace d'aborder son vaisseau amiral. Rapidement, Hera vous fait venir. Les Spectres ont une occasion à saisir.\r\n\r\n{-} Chaque héros reçoit 1 XP.\r\n{-} Les héros reçoivent 100 crédits par héros.",
+      "eventActions": [
+        {
+          "tbText": "Un débat fait rage dans la salle commune du Ghost et vous l'entendez bien avant de le voir. \"Cela pourrait être notre meilleure chance de porter le combat sur le terrain de Thrawn\", insista Ezra tandis qu'il montrait une représentation holographique de Lothal et des nombreux destroyers stellaires qui gravitaient sur son orbite. \"Je sais que cela pourrait être un piège, mais si ce n'en était pas un ? Nous avons travaillé dur pour trouver une brèche qui nous permettrait de répondre aux attaques de Thrawn.\"\r\n\r\nVous les interrompez pour connaître l'objet de leur dispute.\r\n\r\n\"Un ingénieur Impérial nous a envoyé un message\", répond Kanan. \"Il veut déserter, et il prétend pouvoir nous introduire dans la chambre des données qui contient toutes les informations collectées par les droïdes d'infiltration de Thrawn.\" Lorsque le masque de Kanan se tourne dans votre direction, vous ne pouvez qu'imaginer son regard lourd de sens. \"Ces données lui donnent un avantage sur la Rébellion. Mais croire que quelqu'un nous laissera rentrer ? Cela semble trop beau pour être vrai.\"\r\n\r\n\"Nous n'aurons même pas l'occasion d'atterrir avec les gorilles de Thrawn partout dans les parages\", commente Zeb. \"Tous les Impériaux du secteur savent probablement à quoi nous ressemblons.\"\r\n\r\nVous faites un pas en avant. Les Spectres sont une pièce maîtresse de la Rébellion. Ils ne peuvent pas se permettre de prendre un tel risque. Mais vous, vous le pouvez.\r\n\r\n{-} La prochaine mission active est \"L'ordre final\".",
+          "GUID": "792bd98a-a87c-481e-96f0-c28401ed5e07",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        }
+      ]
+    },
+    {
+      "eventName": "No campaign",
+      "GUID": "8fe1b24a-487b-46a0-9e81-94329508e0dc",
+      "eventText": "{-} Chaque héros reçoit 1 XP.\r\n{-} Les héros reçoivent 100 crédits par héros.",
+      "eventActions": []
+    },
+    {
+      "eventName": "Destroy Security Station 1",
+      "GUID": "61503114-385c-48e6-a32f-251e3b6b0b44",
+      "eventText": "La station de sécurité explose dans une pluie d'étincelles.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Security Station 1",
+              "GUID": "5c02f88e-c735-4de1-aea9-747d2acdf553",
+              "theText": "La station de sécurité qui verrouille les portes est protégée par un épais placage.\r\n\r\n{-} Une figurine peut attaquer une station de sécurité (Santé : 2 plus *1*; Défense : 1 {G}).",
+              "buttonList": []
+            }
+          ],
+          "GUID": "6c0e72ae-19e3-47c0-bec0-0151285c08e7",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "Destroy Security Station 2",
+      "GUID": "28f20364-9407-485b-94d8-577c12edde32",
+      "eventText": "La station de sécurité explose dans une pluie d'étincelles.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Security Station 2",
+              "GUID": "23a6b197-75b9-4bc0-9928-de5fd3133763",
+              "theText": "La station de sécurité qui verrouille les portes est protégée par un épais placage.\r\n\r\n{-} Une figurine peut attaquer une station de sécurité (Santé : 2 plus *1*; Défense : 1 {G}).",
+              "buttonList": [
+                {
+                  "GUID": "2f136e8b-6c6c-47ad-8b84-b0078f05a772",
+                  "theText": "Détruire"
+                }
+              ]
+            }
+          ],
+          "GUID": "c43661ff-0b73-4237-9fc5-3af594107fc8",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "Destroy Security Station 3",
+      "GUID": "34e7aa28-168f-41c4-bb94-74fb2932d086",
+      "eventText": "La station de sécurité explose dans une pluie d'étincelles.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Security Station 3",
+              "GUID": "b6a1f694-f355-4cbc-8065-814df68c561c",
+              "theText": "La station de sécurité qui verrouille les portes est protégée par un épais placage.\r\n\r\n{-} Une figurine peut attaquer une station de sécurité (Santé : 2 plus *1*; Défense : 1 {G}).",
+              "buttonList": [
+                {
+                  "GUID": "cf7f1e76-3042-468a-8bd8-e911786092e0",
+                  "theText": "Détruire"
+                }
+              ]
+            }
+          ],
+          "GUID": "689580a5-f764-4951-b118-813fe519b02f",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "Alarm Systems",
+      "GUID": "6924d3df-3788-4be5-80e7-39a6b96c6f63",
+      "eventText": "Alors que la station explose, les alarmes commencent à retentir dans le <i>Chimaera</i>.",
+      "eventActions": []
+    },
+    {
+      "eventName": "Doors unlock",
+      "GUID": "0c957c6d-2b82-4d6f-9ea1-f0a3239983e4",
+      "eventText": "Peu de temps après la destruction de la dernière station de sécurité, les lourdes serrures glissent sur les portes.\r\n\r\n{-} Les portes sont maintenant ouvertes.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Door 1",
+              "GUID": "c973deab-593f-419b-9c84-26acae77b8f9",
+              "theText": "Cette porte mène au centre de traitement des droïdes espions.",
+              "buttonList": [
+                {
+                  "GUID": "e32c66b8-ebc7-48bb-a848-8fe817fc4cc5",
+                  "theText": "{A} Ouvrir"
+                }
+              ]
+            },
+            {
+              "entityName": "Door 2",
+              "GUID": "2e06b0c7-b254-4328-a6a2-a7c9f572bb12",
+              "theText": "Cette porte mène au centre de traitement des droïdes espions.",
+              "buttonList": [
+                {
+                  "GUID": "9f38a80d-fcaa-4240-b86f-e652d3b921ba",
+                  "theText": "{A} Ouvrir"
+                }
+              ]
+            }
+          ],
+          "GUID": "d6e86dc6-0ca7-4a30-8990-5927ccde6a6b",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        },
+        {
+          "repositionText": "Bloquer l'accès aux portes.",
+          "GUID": "5886a5c7-627f-494a-9605-362381fed70f",
+          "eventActionType": 17,
+          "eaName": "Change Reposition Instructions"
+        },
+        {
+          "shortText": "Entrer dans le centre de contrôle.",
+          "longText": null,
+          "GUID": "b911bf69-dd92-4160-a4b8-8a54998b23c3",
+          "eventActionType": 2,
+          "eaName": "Change Objective"
+        },
+        {
+          "theText": "{-} La mission évolue quand une porte s'ouvre.\r\n{-} Les Rebelles perdent quand tous les héros sont blessés.",
+          "GUID": "4c817972-f698-49c7-a10c-b2fa1f95af10",
+          "eventActionType": 1,
+          "eaName": "Change Mission Info"
+        }
+      ]
+    },
+    {
+      "eventName": "What you seek",
+      "GUID": "f74d9a83-c808-4bc0-8aaf-b9e35aceea5f",
+      "eventText": "Les deux portes s'ouvrent et laissent apparaître le centre de contrôle qui est rempli de terminaux traitant des informations précieuses liées aux Rebelles, collectées par les droïdes espions.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Door 1",
+              "GUID": "8b57806b-83d4-4b63-a6f7-9c518423e45a",
+              "theText": "La porte du centre de traitement des droïdes espions est fermement verrouillée.\r\n\r\n{-} Quand les 3 stations de sécurité sont détruites, les portes se déverrouillent.",
+              "buttonList": []
+            },
+            {
+              "entityName": "Door 2",
+              "GUID": "84becdf3-0ccb-4a9a-93ab-9e83f5a24431",
+              "theText": "La porte du centre de traitement des droïdes espions est fermement verrouillée.\r\n\r\n{-} Quand les 3 stations de sécurité sont détruites, les portes se déverrouillent.",
+              "buttonList": []
+            }
+          ],
+          "GUID": "f3913772-4111-40b5-afe1-8704421d52a0",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        },
+        {
+          "tbText": "Le grand amiral lève les yeux de sa tablette. \"Vous êtes en retard. Comme c'est décevant.\"",
+          "GUID": "1929de37-7e93-4b54-9363-59abe7289bf5",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "enemyName": null,
+          "customText": "{-} PATIENCE : Cette figurine et la figurine Impériale la plus proche avec le coût le plus élevé à X cases ou moins gagnent 1 {h} et 1 {g}. X est égal au nombre de pions d'activation Rebelle épuisés.\r\n{Q} Déplacement de 1 pour attaquer {rebel}.\r\n{A} Déplacement de 5 vers le terminal le plus proche.\r\n{A} Déplacement de 5 vers le terminal le plus proche.\r\n{-} ORDRES DE L'AMIRAL : Choisir une autre figurine Impériale ayant le coût le plus élevé et qui peut attaquer, puis la faire attaquer {rebel}.\r\n{-} STIM PACK : Cette figurine élimine 2 {H}.",
+          "modification": null,
+          "repositionInstructions": "",
+          "GUID": "b3fde91e-8a49-4e66-b90c-311ffee72057",
+          "eventActionType": 6,
+          "eaName": "Deploy: DG085/Thrawn"
+        },
+        {
+          "tbText": "{-} <color=\"red\">Thrawn</color> ne peut pas être vaincu. Quand <color=\"red\">Thrawn</color> a subi des {H} supérieurs ou égaux à *1*, il élimine tous les {H}, les héros peuvent le pousser jusqu'à 3 cases et il devient <color=\"red\">Sonné</color>.\r\n{-} Une figurine Rebelle peut dépenser 2 points de déplacement lorsqu'elle est adjacente à un terminal auquel <color=\"red\">Thrawn</color> n'est pas adjacent pour le détruire ({J} ou {I}). Cette figurine peut subir 1 {C} pour relancer n'importe quel nombre de dés, lors de ce test.\r\n{-} Les Rebelles gagnent quand tous les terminaux sont détruits.",
+          "GUID": "05bf243a-e6a6-408e-a3fb-7fdc35a1fdb6",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "repositionText": "Bloquer l'accès aux terminaux.",
+          "GUID": "6a7ecf49-5421-4bdd-946b-d8c704585f50",
+          "eventActionType": 17,
+          "eaName": "Change Reposition Instructions"
+        },
+        {
+          "shortText": "Détruire les terminaux (&Terminals destroyed&/6).",
+          "longText": null,
+          "GUID": "2c46e045-b62a-4128-b94b-cb22b697fafe",
+          "eventActionType": 2,
+          "eaName": "Change Objective"
+        },
+        {
+          "theText": "{-} <color=\"red\">Thrawn</color> ne peut pas être vaincu. Quand <color=\"red\">Thrawn</color> a subi des {H} supérieurs ou égaux à *1*, il élimine tous les {H}, les héros peuvent le pousser jusqu'à 3 cases et il devient <color=\"red\">Sonné</color>.\r\n{-} Une figurine Rebelle peut dépenser 2 points de déplacement lorsqu'elle est adjacente à un terminal auquel <color=\"red\">Thrawn</color> n'est pas adjacent pour le détruire ({J} ou {I}). Cette figurine peut subir 1 {C} pour relancer n'importe quel nombre de dés, lors de ce test.\r\n{-} Les Rebelles gagnent quand tous les terminaux sont détruits.",
+          "GUID": "ed202302-e178-4ce9-af3e-408fd73f68ae",
+          "eventActionType": 1,
+          "eaName": "Change Mission Info"
+        }
+      ]
+    },
+    {
+      "eventName": "Terminal Attempt 1",
+      "GUID": "5991d36e-384a-4bee-9f56-f1e7e986eb30",
+      "eventText": "",
+      "eventActions": [
+        {
+          "mainText": "Vous commencez à pirater les systèmes du terminal, en essayant de déclencher une surcharge.\r\n\r\n{-} Effectuez un test {J} ou {I}. Appliquez +1 {B} au test pour chaque pion Stress présent sur le terminal, puis défaussez ces pions Stress. Entrez le nombre de réussites ci-dessous.",
+          "failText": "",
+          "inputList": [
+            {
+              "GUID": "55c8d359-011b-4a25-aff3-f02a7aa7cdf9",
+              "theText": "Les systèmes de sécurité sont trop complexes. Il faut continuer à essayer."
+            }
+          ],
+          "GUID": "12bd6448-e201-4a59-8845-005cedf7e194",
+          "eventActionType": 20,
+          "eaName": "Input Prompt"
+        }
+      ]
+    },
+    {
+      "eventName": "Destroy Terminal 1",
+      "GUID": "e8032470-574f-4165-bc0a-ddd617f24342",
+      "eventText": "Le défilement de données s'arrête alors que la surcharge fait exploser le terminal.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Terminal 1",
+              "GUID": "d5787194-c664-471f-b2c0-5c430970e1ad",
+              "theText": "Les données sur l'Alliance Rebelle recueillies par les droïdes espions défilent sur l'écran du terminal.\r\n\r\n{-} Une figurine Rebelle peut dépenser 2 points de déplacement lorsqu'elle est adjacente à un terminal auquel <color=\"red\">Thrawn</color> n'est pas adjacent pour le détruire ({J} ou {I}). Cette figurine peut subir 1 {C} pour relancer n'importe quel nombre de dés, lors de ce test.",
+              "buttonList": [
+                {
+                  "GUID": "208f6578-1dfe-4ddb-be77-dd07f5a742d8",
+                  "theText": "Essayer de détruire"
+                }
+              ]
+            }
+          ],
+          "GUID": "fcaee985-62cb-47ed-a266-998de857d075",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "Terminal Attempt 2",
+      "GUID": "6d40e0fb-35aa-4ea7-bfc9-fea634f827d9",
+      "eventText": "",
+      "eventActions": [
+        {
+          "mainText": "Vous commencez à pirater les systèmes du terminal, en essayant de déclencher une surcharge.\r\n\r\n{-} Effectuez un test {J} ou {I}. Appliquez +1 {B} au test pour chaque pion Stress présent sur le terminal, puis défaussez ces pions Stress. Entrez le nombre de réussites ci-dessous.",
+          "failText": "",
+          "inputList": [
+            {
+              "GUID": "e4b46946-3320-4ec1-b30e-f332a997ed80",
+              "theText": "Les systèmes de sécurité sont trop complexes. Il faut continuer à essayer."
+            }
+          ],
+          "GUID": "c2d2d56f-d988-4e2f-b3af-d5c65f399fa2",
+          "eventActionType": 20,
+          "eaName": "Input Prompt"
+        }
+      ]
+    },
+    {
+      "eventName": "Destroy Terminal 2",
+      "GUID": "e1a3ed26-84f2-4e67-9801-cbca929ee628",
+      "eventText": "Le défilement de données s'arrête alors que la surcharge fait exploser le terminal.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Terminal 2",
+              "GUID": "ebf57e82-5834-47b3-97ca-f27bc1b3c8a3",
+              "theText": "Les données sur l'Alliance Rebelle recueillies par les droïdes espions défilent sur l'écran du terminal.\r\n\r\n{-} Une figurine Rebelle peut dépenser 2 points de déplacement lorsqu'elle est adjacente à un terminal auquel <color=\"red\">Thrawn</color> n'est pas adjacent pour le détruire ({J} ou {I}). Cette figurine peut subir 1 {C} pour relancer n'importe quel nombre de dés, lors de ce test.",
+              "buttonList": [
+                {
+                  "GUID": "05dfb1a4-8ea3-45ad-a467-af7d9076955c",
+                  "theText": "Essayer de détruire"
+                }
+              ]
+            }
+          ],
+          "GUID": "37cd826c-494a-4206-8eee-dbe26852d916",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "Terminal Attempt 3",
+      "GUID": "c9c14439-fd23-48f5-bfef-5e8ec114f332",
+      "eventText": "",
+      "eventActions": [
+        {
+          "mainText": "Vous commencez à pirater les systèmes du terminal, en essayant de déclencher une surcharge.\r\n\r\n{-} Effectuez un test {J} ou {I}. Appliquez +1 {B} au test pour chaque pion Stress présent sur le terminal, puis défaussez ces pions Stress. Entrez le nombre de réussites ci-dessous.",
+          "failText": "",
+          "inputList": [
+            {
+              "GUID": "0881982f-7543-4e17-84d2-01f447b2511f",
+              "theText": "Les systèmes de sécurité sont trop complexes. Il faut continuer à essayer."
+            }
+          ],
+          "GUID": "1d7ace2d-0b9a-43d7-afe0-b4df6a31048c",
+          "eventActionType": 20,
+          "eaName": "Input Prompt"
+        }
+      ]
+    },
+    {
+      "eventName": "Destroy Terminal 3",
+      "GUID": "63d419dc-fa71-4f73-a67a-0105c1ae3b43",
+      "eventText": "Le défilement de données s'arrête alors que la surcharge fait exploser le terminal.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Terminal 3",
+              "GUID": "aa78be65-11d9-4aa4-b305-c068bd06468d",
+              "theText": "Les données sur l'Alliance Rebelle recueillies par les droïdes espions défilent sur l'écran du terminal.\r\n\r\n{-} Une figurine Rebelle peut dépenser 2 points de déplacement lorsqu'elle est adjacente à un terminal auquel <color=\"red\">Thrawn</color> n'est pas adjacent pour le détruire ({J} ou {I}). Cette figurine peut subir 1 {C} pour relancer n'importe quel nombre de dés, lors de ce test.",
+              "buttonList": [
+                {
+                  "GUID": "0bad9db2-198f-4b1f-9955-d6cc2727807a",
+                  "theText": "Essayer de détruire"
+                }
+              ]
+            }
+          ],
+          "GUID": "da91a6f5-9e56-4ab2-8b0f-dc2245f99a87",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "Terminal Attempt 4",
+      "GUID": "2a481b73-f8e9-48f1-8e9f-73b775b8b5db",
+      "eventText": "",
+      "eventActions": [
+        {
+          "mainText": "Vous commencez à pirater les systèmes du terminal, en essayant de déclencher une surcharge.\r\n\r\n{-} Effectuez un test {J} ou {I}. Appliquez +1 {B} au test pour chaque pion Stress présent sur le terminal, puis défaussez ces pions Stress. Entrez le nombre de réussites ci-dessous.",
+          "failText": "",
+          "inputList": [
+            {
+              "GUID": "fa7d1074-805a-43cc-babb-a428d1ff7564",
+              "theText": "Les systèmes de sécurité sont trop complexes. Il faut continuer à essayer."
+            }
+          ],
+          "GUID": "ba62c669-82a7-4561-ac59-60a0fa9083cf",
+          "eventActionType": 20,
+          "eaName": "Input Prompt"
+        }
+      ]
+    },
+    {
+      "eventName": "Destroy Terminal 4",
+      "GUID": "2fb8c495-8240-41a6-98db-fa372b74793c",
+      "eventText": "Le défilement de données s'arrête alors que la surcharge fait exploser le terminal.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Terminal 4",
+              "GUID": "b67fba2d-e2cd-41fc-ab2b-9a9a3373eb4b",
+              "theText": "Les données sur l'Alliance Rebelle recueillies par les droïdes espions défilent sur l'écran du terminal.\r\n\r\n{-} Une figurine Rebelle peut dépenser 2 points de déplacement lorsqu'elle est adjacente à un terminal auquel <color=\"red\">Thrawn</color> n'est pas adjacent pour le détruire ({J} ou {I}). Cette figurine peut subir 1 {C} pour relancer n'importe quel nombre de dés, lors de ce test.",
+              "buttonList": [
+                {
+                  "GUID": "67f1d7c1-6a80-4e65-9c7d-e7c95fae9181",
+                  "theText": "Essayer de détruire"
+                }
+              ]
+            }
+          ],
+          "GUID": "45412933-31ff-4e69-9ae8-0e4c36bc4895",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "Terminal Attempt 5",
+      "GUID": "a06ee9f5-2049-4570-b52a-a572dab14028",
+      "eventText": "",
+      "eventActions": [
+        {
+          "mainText": "Vous commencez à pirater les systèmes du terminal, en essayant de déclencher une surcharge.\r\n\r\n{-} Effectuez un test {J} ou {I}. Appliquez +1 {B} au test pour chaque pion Stress présent sur le terminal, puis défaussez ces pions Stress. Entrez le nombre de réussites ci-dessous.",
+          "failText": "",
+          "inputList": [
+            {
+              "GUID": "fee7a178-e784-4684-8219-2f05bc1bfa8d",
+              "theText": "Les systèmes de sécurité sont trop complexes. Il faut continuer à essayer."
+            }
+          ],
+          "GUID": "ae197379-e609-436f-bdb5-279a83686e6a",
+          "eventActionType": 20,
+          "eaName": "Input Prompt"
+        }
+      ]
+    },
+    {
+      "eventName": "Destroy Terminal 5",
+      "GUID": "c3f1c318-4722-4f5d-8a71-8394047e36dc",
+      "eventText": "Le défilement de données s'arrête alors que la surcharge fait exploser le terminal.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Terminal 5",
+              "GUID": "1cb7e915-7c9b-472c-880b-2e88944acef0",
+              "theText": "Les données sur l'Alliance Rebelle recueillies par les droïdes espions défilent sur l'écran du terminal.\r\n\r\n{-} Une figurine Rebelle peut dépenser 2 points de déplacement lorsqu'elle est adjacente à un terminal auquel <color=\"red\">Thrawn</color> n'est pas adjacent pour le détruire ({J} ou {I}). Cette figurine peut subir 1 {C} pour relancer n'importe quel nombre de dés, lors de ce test.",
+              "buttonList": [
+                {
+                  "GUID": "84df77a7-6d0e-475f-b204-aa54068bc2b5",
+                  "theText": "Essayer de détruire"
+                }
+              ]
+            }
+          ],
+          "GUID": "847f1fb6-533d-455e-87b7-5e3b5d5d9752",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "Terminal Attempt 6",
+      "GUID": "5aa40eea-70b4-4172-a68e-ec2236eabf51",
+      "eventText": "",
+      "eventActions": [
+        {
+          "mainText": "Vous commencez à pirater les systèmes du terminal, en essayant de déclencher une surcharge.\r\n\r\n{-} Effectuez un test {J} ou {I}. Appliquez +1 {B} au test pour chaque pion Stress présent sur le terminal, puis défaussez ces pions Stress. Entrez le nombre de réussites ci-dessous.",
+          "failText": "",
+          "inputList": [
+            {
+              "GUID": "b7c8ea0d-f569-4dd9-8bd4-edf6a58bbdf2",
+              "theText": "Les systèmes de sécurité sont trop complexes. Il faut continuer à essayer."
+            }
+          ],
+          "GUID": "79503611-c185-4574-a83e-2266584e4c63",
+          "eventActionType": 20,
+          "eaName": "Input Prompt"
+        }
+      ]
+    },
+    {
+      "eventName": "Destroy Terminal 6",
+      "GUID": "89841375-15c8-4cfe-bc56-5c35e8445549",
+      "eventText": "Le défilement de données s'arrête alors que la surcharge fait exploser le terminal.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Terminal 6",
+              "GUID": "3b9eda7c-e4d4-44f1-aae4-60637e8735f8",
+              "theText": "Les données sur l'Alliance Rebelle recueillies par les droïdes espions défilent sur l'écran du terminal.\r\n\r\n{-} Une figurine Rebelle peut dépenser 2 points de déplacement lorsqu'elle est adjacente à un terminal auquel <color=\"red\">Thrawn</color> n'est pas adjacent pour le détruire ({J} ou {I}). Cette figurine peut subir 1 {C} pour relancer n'importe quel nombre de dés, lors de ce test.",
+              "buttonList": [
+                {
+                  "GUID": "9998e704-6d0e-420e-ac30-7d5f49e07520",
+                  "theText": "Essayer de détruire"
+                }
+              ]
+            }
+          ],
+          "GUID": "4c138255-41ec-4749-b588-5555c71b3d52",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "Personal Guards 1",
+      "GUID": "cafaa112-4ecb-451b-ac64-4903d8aa3193",
+      "eventText": "Un trooper blessé s'éloigne et siffle dans le comlink : \"Des Rebelles ! Envoyez des renforts !\"",
+      "eventActions": [
+        {
+          "enemyName": null,
+          "customText": "",
+          "modification": null,
+          "repositionInstructions": "",
+          "GUID": "033a7f7b-b7b7-4793-8110-fca93a1b79c0",
+          "eventActionType": 6,
+          "eaName": "Deploy: DG004/Imperial Officer"
+        },
+        {
+          "enemyName": null,
+          "customText": "",
+          "modification": null,
+          "repositionInstructions": "",
+          "GUID": "fa59b998-be93-473f-b705-48528f154a10",
+          "eventActionType": 6,
+          "eaName": "Deploy: DG058/Death Trooper (Elite)"
+        }
+      ]
+    },
+    {
+      "eventName": "Personal Guards 2",
+      "GUID": "0c926a2e-9c15-4f7d-a5ad-dbdcff695ce5",
+      "eventText": "Un trooper blessé s'éloigne et siffle dans le comlink : \"Des Rebelles ! Envoyez des renforts !\"",
+      "eventActions": [
+        {
+          "enemyName": null,
+          "customText": "",
+          "modification": null,
+          "repositionInstructions": "",
+          "GUID": "9a3fcc9a-a285-4fe7-b86c-3a5a6c14538b",
+          "eventActionType": 6,
+          "eaName": "Deploy: DG004/Imperial Officer"
+        },
+        {
+          "enemyName": null,
+          "customText": "",
+          "modification": null,
+          "repositionInstructions": "",
+          "GUID": "dc461bff-5211-4201-8c0a-ed207fc1e27f",
+          "eventActionType": 6,
+          "eaName": "Deploy: DG058/Death Trooper (Elite)"
+        }
+      ]
+    }
+  ],
+  "mapEntities": [
+    {
+      "entityName": "Crate1",
+      "GUID": "dcf1e03e-e328-4f79-8427-e0a0bfc64f82",
+      "mainText": "Une vieille caisse de ravitaillement.",
+      "buttonList": [
+        {
+          "GUID": "a788caa6-fca0-4ff0-bfcf-bf7869202454",
+          "theText": "{A} Ouvrir"
+        }
+      ]
+    },
+    {
+      "entityName": "Crate2",
+      "GUID": "461e69e0-7c26-42a1-ad2a-a5e71b4f7707",
+      "mainText": "Une vieille caisse de ravitaillement.",
+      "buttonList": [
+        {
+          "GUID": "5f37616e-9025-4aef-8c02-239c19f1f65f",
+          "theText": "{A} Ouvrir"
+        }
+      ]
+    },
+    {
+      "entityName": "Entrance",
+      "GUID": "a343a128-3b10-48ff-878f-71c89176d776",
+      "mainText": "Déployer les héros ici.",
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Green 1",
+      "GUID": "c8062d94-a52f-4458-b2cf-3c7b515747e5",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Green 3",
+      "GUID": "64b4dbf2-4e39-4ce7-a5fe-94eed25c16d2",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP DTrooper 1",
+      "GUID": "81ead058-7663-414c-aed5-13a096cc71f9",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP DTrooper 2",
+      "GUID": "9fb82f6f-4b68-458f-86b1-c8ab8f9598d4",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Probe Droid",
+      "GUID": "f40b0f2b-0630-4e3e-b552-da7f9f284595",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "Door 1",
+      "GUID": "2a158b11-3bcf-4026-b599-f47759227c01",
+      "mainText": "La porte du centre de traitement des droïdes espions est fermement verrouillée.\r\n\r\n{-} Quand les 3 stations de sécurité sont détruites, les portes se déverrouillent.",
+      "buttonList": []
+    },
+    {
+      "entityName": "Door 2",
+      "GUID": "494a6400-e85b-46c5-81db-50f522958bef",
+      "mainText": "La porte du centre de traitement des droïdes espions est fermement verrouillée.\r\n\r\n{-} Quand les 3 stations de sécurité sont détruites, les portes se déverrouillent.",
+      "buttonList": []
+    },
+    {
+      "entityName": "Security Station 1",
+      "GUID": "f8454455-e420-4398-973b-849a153501c7",
+      "mainText": "La station de sécurité qui verrouille les portes est protégée par un épais placage.\r\n\r\n{-} Une figurine peut attaquer une station de sécurité (Santé : 2 plus *1*; Défense : 1 {G}).",
+      "buttonList": [
+        {
+          "GUID": "6a0b7ac2-91fc-4559-bf14-c0e03ff7f8b9",
+          "theText": "Détruire"
+        }
+      ]
+    },
+    {
+      "entityName": "Security Station 2",
+      "GUID": "2429899a-3ebc-4fe9-b14c-e2fade7677bd",
+      "mainText": "La station de sécurité qui verrouille les portes est protégée par un épais placage.\r\n\r\n{-} Une figurine peut attaquer une station de sécurité (Santé : 2 plus *1*; Défense : 1 {G}).",
+      "buttonList": [
+        {
+          "GUID": "6ffee191-5bcb-4210-9e0f-7265c81a5b9f",
+          "theText": "Détruire"
+        }
+      ]
+    },
+    {
+      "entityName": "Security Station 3",
+      "GUID": "8d3cf270-8255-49a6-b996-a9b6fed48de3",
+      "mainText": "La station de sécurité qui verrouille les portes est protégée par un épais placage.\r\n\r\n{-} Une figurine peut attaquer une station de sécurité (Santé : 2 plus *1*; Défense : 1 {G}).",
+      "buttonList": [
+        {
+          "GUID": "33492655-8e8b-43f2-a73f-83400d2f2143",
+          "theText": "Détruire"
+        }
+      ]
+    },
+    {
+      "entityName": "DP Door",
+      "GUID": "617a328e-b32e-4740-9979-f76d0672a385",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Red",
+      "GUID": "a7c336f7-48c6-4fd0-b463-6d8ac66e0f34",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Yellow",
+      "GUID": "41ef5c05-42b0-4a2f-8dff-a15ae4ae0579",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "Terminal 1",
+      "GUID": "f1219e2f-961a-4017-8f45-d0365090dc7b",
+      "mainText": "Les données sur l'Alliance Rebelle recueillies par les droïdes espions défilent sur l'écran du terminal.\r\n\r\n{-} Une figurine Rebelle peut dépenser 2 points de déplacement lorsqu'elle est adjacente à un terminal auquel <color=\"red\">Thrawn</color> n'est pas adjacent pour le détruire ({J} ou {I}). Cette figurine peut subir 1 {C} pour relancer n'importe quel nombre de dés, lors de ce test.",
+      "buttonList": [
+        {
+          "GUID": "0e179441-997f-4d74-a266-f9e5189a50c0",
+          "theText": "Essayer de détruire"
+        }
+      ]
+    },
+    {
+      "entityName": "Terminal 2",
+      "GUID": "5d8ff54b-b721-40d1-8fd6-870b227dc953",
+      "mainText": "Les données sur l'Alliance Rebelle recueillies par les droïdes espions défilent sur l'écran du terminal.\r\n\r\n{-} Une figurine Rebelle peut dépenser 2 points de déplacement lorsqu'elle est adjacente à un terminal auquel <color=\"red\">Thrawn</color> n'est pas adjacent pour le détruire ({J} ou {I}). Cette figurine peut subir 1 {C} pour relancer n'importe quel nombre de dés, lors de ce test.",
+      "buttonList": [
+        {
+          "GUID": "e88e4229-d47a-419f-928a-1e90fccaa118",
+          "theText": "Essayer de détruire"
+        }
+      ]
+    },
+    {
+      "entityName": "Terminal 3",
+      "GUID": "b1448b99-3a6a-4aa5-924c-9d7523485557",
+      "mainText": "Les données sur l'Alliance Rebelle recueillies par les droïdes espions défilent sur l'écran du terminal.\r\n\r\n{-} Une figurine Rebelle peut dépenser 2 points de déplacement lorsqu'elle est adjacente à un terminal auquel <color=\"red\">Thrawn</color> n'est pas adjacent pour le détruire ({J} ou {I}). Cette figurine peut subir 1 {C} pour relancer n'importe quel nombre de dés, lors de ce test.",
+      "buttonList": [
+        {
+          "GUID": "76719adb-fbc1-428b-aedc-a09384797f9a",
+          "theText": "Essayer de détruire"
+        }
+      ]
+    },
+    {
+      "entityName": "Terminal 4",
+      "GUID": "d19bfe77-6ae1-4f42-827d-a73ea49fdb1f",
+      "mainText": "Les données sur l'Alliance Rebelle recueillies par les droïdes espions défilent sur l'écran du terminal.\r\n\r\n{-} Une figurine Rebelle peut dépenser 2 points de déplacement lorsqu'elle est adjacente à un terminal auquel <color=\"red\">Thrawn</color> n'est pas adjacent pour le détruire ({J} ou {I}). Cette figurine peut subir 1 {C} pour relancer n'importe quel nombre de dés, lors de ce test.",
+      "buttonList": [
+        {
+          "GUID": "de26f9f3-fd3d-4014-8a4a-f5cdfb3ea400",
+          "theText": "Essayer de détruire"
+        }
+      ]
+    },
+    {
+      "entityName": "Terminal 5",
+      "GUID": "2fb9e880-7d2b-4486-b1c8-926ac735ef9d",
+      "mainText": "Les données sur l'Alliance Rebelle recueillies par les droïdes espions défilent sur l'écran du terminal.\r\n\r\n{-} Une figurine Rebelle peut dépenser 2 points de déplacement lorsqu'elle est adjacente à un terminal auquel <color=\"red\">Thrawn</color> n'est pas adjacent pour le détruire ({J} ou {I}). Cette figurine peut subir 1 {C} pour relancer n'importe quel nombre de dés, lors de ce test.",
+      "buttonList": [
+        {
+          "GUID": "b3881119-d2da-4f15-9df6-273271337ace",
+          "theText": "Essayer de détruire"
+        }
+      ]
+    },
+    {
+      "entityName": "Terminal 6",
+      "GUID": "3ac9a4b8-6e03-4e79-a97f-aa8ec3122037",
+      "mainText": "Les données sur l'Alliance Rebelle recueillies par les droïdes espions défilent sur l'écran du terminal.\r\n\r\n{-} Une figurine Rebelle peut dépenser 2 points de déplacement lorsqu'elle est adjacente à un terminal auquel <color=\"red\">Thrawn</color> n'est pas adjacent pour le détruire ({J} ou {I}). Cette figurine peut subir 1 {C} pour relancer n'importe quel nombre de dés, lors de ce test.",
+      "buttonList": [
+        {
+          "GUID": "950c5218-b27a-437a-8086-2e2cf1992824",
+          "theText": "Essayer de détruire"
+        }
+      ]
+    }
+  ],
+  "initialGroups": [
+    {
+      "cardName": "Death Trooper",
+      "customInstructions": ""
+    },
+    {
+      "cardName": "Death Trooper",
+      "customInstructions": ""
+    },
+    {
+      "cardName": "Probe Droid",
+      "customInstructions": ""
+    }
+  ]
+}

--- a/ImperialCommander2/Assets/Resources/Languages/Fr/Missions/Other/OTHER39_FR.json
+++ b/ImperialCommander2/Assets/Resources/Languages/Fr/Missions/Other/OTHER39_FR.json
@@ -1,0 +1,602 @@
+{
+  "languageID": "French (FR)",
+  "missionProperties": {
+    "missionName": "Le subterfuge du pirate",
+    "missionDescription": "",
+    "missionInfo": "",
+    "campaignName": "Extension \"Hondo Ohnaka (Ami de Circonstance)\"",
+    "startingObjective": "",
+    "repositionOverride": "Bloquer l'accès au droïde infiltrateur E-XD.",
+    "additionalMissionInfo": ""
+  },
+  "events": [
+    {
+      "eventName": "Open Crate 1",
+      "GUID": "2dec36b9-ce77-4bf6-8c35-9489e6573609",
+      "eventText": "Vous fouillez la caisse et prenez ce qui vous semble utile.\r\n\r\nPiochez une carte Ravitaillement. Vous gagnez 1 médipack. Récupérez ce pion.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Crate1",
+              "GUID": "0d0828b6-9a3f-43af-bce4-e3a2d00bfa16",
+              "theText": "Une vieille caisse de ravitaillement.",
+              "buttonList": [
+                {
+                  "GUID": "6969461d-faa0-4da9-9766-2fe9fdbdd1de",
+                  "theText": "{A} Ouvrir"
+                }
+              ]
+            }
+          ],
+          "GUID": "8eb6c4bb-fd64-4ae8-9b6d-a5ba3f737e6a",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "Open Crate 2",
+      "GUID": "74bbaee9-47db-48c2-b09c-7d0940adf6ab",
+      "eventText": "Vous fouillez la caisse et prenez ce qui vous semble utile.\r\n\r\nPiochez une carte Ravitaillement. Vous gagnez 1 médipack. Récupérez ce pion.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Crate2",
+              "GUID": "4004d93e-61d9-4e93-ab5e-194431b70b5d",
+              "theText": "Une vieille caisse de ravitaillement.",
+              "buttonList": []
+            }
+          ],
+          "GUID": "a6f06d59-b18c-465a-acc1-85db4a122e25",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "Open Crate 3",
+      "GUID": "4c60aea9-45d0-4dbe-9bea-27d51eba9079",
+      "eventText": "Vous fouillez la caisse et prenez ce qui vous semble utile.\r\n\r\nPiochez une carte Ravitaillement. Vous gagnez 1 médipack. Récupérez ce pion.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Crate3",
+              "GUID": "afe678a8-ef71-49a6-9629-ef540cf6bed3",
+              "theText": "Une vieille caisse de ravitaillement.",
+              "buttonList": []
+            }
+          ],
+          "GUID": "50b5bf42-216f-45db-925e-d733f34fdd76",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "Mission Briefing",
+      "GUID": "edc56ae0-7e4f-4ecd-9176-26e69bfd835a",
+      "eventText": "Vous coincez Hondo dans sa planque au moment où il ouvre la caisse. Se confondant en excuses, le pirate accepte de vous céder la cargaison Impériale.\r\n\r\n{-} Déployez les héros sur la case bleue en surbrillance.\r\n{-} La porte est verrouillée.",
+      "eventActions": [
+        {
+          "tbText": "Hondo s'écarte au moment où un droïde infiltrateur E-XD jaillit de la caisse.",
+          "GUID": "1efa31db-8865-44cd-837a-9d1c4afe11b8",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "E-XD",
+              "GUID": "4a01aae6-61dc-4796-b665-9098a5c92aec",
+              "theText": null,
+              "buttonList": []
+            }
+          ],
+          "GUID": "517899d4-648d-45f2-ac09-7cd7d9814d45",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        },
+        {
+          "GUID": "ae59cebd-1c6b-4a4d-8338-88fe0c34020b",
+          "eventActionType": 21,
+          "eaName": "Custom Deployment: E-XD Infiltrator Droid",
+          "repositionInstructions": "",
+          "surges": "{B}: Perforant 2",
+          "bonuses": "GÉNÉRATEURS DE CHARGE: Cette figurine gagne 1 {h}.\nRÉPARATIONS AUTOMATIQUES: Cette figurine élimine 2 {H}.",
+          "keywords": "+5 Santé\r\n+4 Précision",
+          "abilities": "",
+          "customText": "{Q} Déplacement de 2 pour attaquer {rebel}.\r\n{A} Déplacement de 2 pour s'éloigner des Rebelles.\r\n{A} Déplacement de 4 pour s'éloigner des Rebelles.\r\n{-} Cette figurine gagne 1 {g}.",
+          "cardName": "Droïde Infiltrateur E-XD"
+        },
+        {
+          "tbText": "{-} Le pion Mission Impérial représente le droïde infiltrateur E-XD. \r\n{-} Si le E-XD a été vaincu, une figurine peut interagir avec la porte ({K} ou {I}) pour essayer de l'ouvrir. Cette figurine peut subir 1 {C} durant ce test pour relancer n'importe quel nombre de dés.\r\n{-} La mission évolue quand la porte s'ouvre.\r\n{-} Les Rebelles perdent quand tous les héros sont blessés.",
+          "GUID": "323e6074-8a06-4b69-99f2-40751a8b4757",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "E-XD",
+              "GUID": "39084945-6af7-48d5-8a80-d0de59177ea2",
+              "theText": null,
+              "buttonList": []
+            }
+          ],
+          "GUID": "c497dffd-30f9-4b7b-997d-d23d277467e4",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        },
+        {
+          "shortText": "Vaincre le droïde infiltrateur E-XD.",
+          "longText": null,
+          "GUID": "a71ea5ab-b407-4c55-9e18-3d0dd6699de2",
+          "eventActionType": 2,
+          "eaName": "Change Objective"
+        },
+        {
+          "theText": "{-} Le pion Mission Impérial représente le droïde infiltrateur E-XD. \r\n{-} La porte est verrouillée. Si le E-XD a été vaincu, une figurine peut interagir avec la porte ({K} ou {I}) pour essayer de l'ouvrir. Cette figurine peut subir 1 {C} durant ce test pour relancer n'importe quel nombre de dés.\r\n{-} La mission évolue quand la porte s'ouvre.\r\n{-} Les Rebelles perdent quand tous les héros sont blessés.",
+          "GUID": "fa10d00f-0761-47ff-a3e4-91cf0645eb70",
+          "eventActionType": 1,
+          "eaName": "Change Mission Info"
+        }
+      ]
+    },
+    {
+      "eventName": "End of Mission - Rebels win",
+      "GUID": "69b80fad-5e0e-46cd-a70e-defa45de4db6",
+      "eventText": "Une fois la balise de pistage discrètement posée, vous faites mine d'être vaincus et battez en retraite. Les données de ce droïde devraient se révéler très utiles pour la Rébellion.\r\n\r\n{-} Les Rebelles remportent la mission !\r\n{-} Les héros reçoivent 100 crédits par héros.",
+      "eventActions": [
+        {
+          "mainText": "Jouez-vous cette mission dans le cadre de la mini-campagne \"Tyrans de Lothal\" ?",
+          "buttonList": [
+            {
+              "GUID": "2ff51d84-9e77-4684-bbb6-42ca3784e270",
+              "theText": "Oui"
+            },
+            {
+              "GUID": "7d783a89-f3a9-4728-8dbc-bd52787bdbd6",
+              "theText": "Non"
+            }
+          ],
+          "GUID": "fa160c96-ff1c-4306-ad5f-f40d51ef9331",
+          "eventActionType": 5,
+          "eaName": "Question Prompt"
+        }
+      ]
+    },
+    {
+      "eventName": "End of Mission - Rebels lose",
+      "GUID": "9e960fce-d271-468c-8d6c-233bc752aa52",
+      "eventText": "Incapables de rattraper Hondo ou le mystérieux droïde Impérial, vous n'avez d'autre choix que de battre en retraite vers votre appareil.\r\n\r\n{-} Les Rebelles perdent la mission.\r\n{-} Si vous jouez cette mission en tant que mission annexe, l'Empire reçoit <color=\"red\">Hondo Ohnaka</color> (Ami de Circonstance) en tant qu'antagoniste.",
+      "eventActions": [
+        {
+          "mainText": "Jouez-vous cette mission dans le cadre de la mini-campagne \"Tyrans de Lothal\" ?",
+          "buttonList": [
+            {
+              "GUID": "487bffdf-5024-40d2-8f74-44eb5a57e4f8",
+              "theText": "Oui"
+            },
+            {
+              "GUID": "abe30545-8e23-4487-80e7-13471e97868f",
+              "theText": "Non"
+            }
+          ],
+          "GUID": "922d0b18-3b9c-4426-b8b1-9d79afd7d873",
+          "eventActionType": 5,
+          "eaName": "Question Prompt"
+        }
+      ]
+    },
+    {
+      "eventName": "Mini campaign Win",
+      "GUID": "1fb0c0b1-7388-42f6-9c4c-801de27f03a5",
+      "eventText": "Une fois les Impériaux partis, vous parvenez à coincer Hondo. \"Je vous ai peut-être trahis, mais l'Empire ne m'a pas laissé le choix\", explique-t-il. \"En plus, mon droïde a disparu et je me retrouve les mains vides. Vraiment, nous partageons une même tragédie.\r\n\r\nN-4M vous appelle. \"Je reçois la télémétrie du droïde infiltrateur et la transmets à nos alliés Rebelles.\"\r\n\r\nVous dites à Hondo que vous serez moins charitables la prochaine fois qu'il se mettra en travers de votre chemin et regagnez votre vaisseau.\r\n\r\n{-} Chaque héros reçoit 1 XP.\r\n{-} Les héros reçoivent 100 crédits par héros.",
+      "eventActions": [
+        {
+          "tbText": "Vous vous amarrez à un Cargo VCX-100. Une fois à bord, vous rencontrez le reste de l'équipe, et la Capitaine Hera Syndulla. \"Toute l'aide que nous pourrons recevoir sera la bienvenue\", confirme-t-elle, \"et puisque vous avez gagné la confiance de mon équipe, je vous confie aussi la mienne. Nous avons plus de travail à accomplir que de bras pour le faire.\"\r\n\r\n\"Avez-vous entendu parler du Grand Amiral Thrawn\" ? Il vient de mettre tout le secteur en alerte rouge. On peut à peine bouger le petit doigt. Elle s'appuie contre la petite table au milieu de la pièce. \"Nous avons des alliés sur Seelos, Wolfe et Gregor. Ils ont récupéré des codes Impériaux sur un marcheur volé, mais ils ont besoin d'aide pour échapper à l'Empire. Nous avons également une piste qui nous mène à la cachette d'un vieux contrebandier sur Dévaron. Elle contient les cartes des meilleures routes de contrebande du secteur. Si nous arrivons à les obtenir, nous pourrons éviter les patrouilles Impériales et il nous sera même possible de nous passer des codes.\" Elle se tourne vers vous. \"Si vous pouvez nous aider à accomplir ces missions, j'enverrai un membre de mon équipage avec vous.\"\r\n\r\n{-} Les héros choisissent collectivement s'ils souhaitent aider Wolffe et Gregor ou s'ils préfèrent fouiller la cachette du contrebandier.\r\n{-} Si les héros choisissent d'aider Wolffe et Gregor, la prochaine mission active est \"Les Dunes de Seelos\".\r\n{-} Si les héros choisissent de fouiller la cachette du contrebandier, la prochaine mission active est \"Duel sur Dévaron\".",
+          "GUID": "00b502cf-6261-4d81-94b1-9365d28eb78b",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        }
+      ]
+    },
+    {
+      "eventName": "Mini campaign Defeat",
+      "GUID": "ee9e6f21-9b9f-47ca-b982-44b59453a837",
+      "eventText": "Vous vous glissez dans un entrepôt rempli de caisses et semez vos poursuivants. Lorsque vous en ressortez, Hondo et le droïde Impérial ont disparu. Vous vous inquiétez concernant le droïde infiltrateur... et le danger que représente Hondo si ses contacts avec l'Empire ne relèvent pas d'une simple coïncidence.\r\n\r\nIl est maintenant temps de faire la connaissance de vos nouveaux alliés.\r\n\r\n{-} Chaque héros reçoit 1 XP.\r\n{-} Les héros reçoivent 100 crédits par héros.",
+      "eventActions": [
+        {
+          "tbText": "Vous vous amarrez à un Cargo VCX-100. Une fois à bord, vous rencontrez le reste de l'équipe, et la Capitaine Hera Syndulla. \"Toute l'aide que nous pourrons recevoir sera la bienvenue\", confirme-t-elle, \"et puisque vous avez gagné la confiance de mon équipe, je vous confie aussi la mienne. Nous avons plus de travail à accomplir que de bras pour le faire.\"\r\n\r\n\"Avez-vous entendu parler du Grand Amiral Thrawn\" ? Il vient de mettre tout le secteur en alerte rouge. On peut à peine bouger le petit doigt. Elle s'appuie contre la petite table au milieu de la pièce. \"Nous avons des alliés sur Seelos, Wolfe et Gregor. Ils ont récupéré des codes Impériaux sur un marcheur volé, mais ils ont besoin d'aide pour échapper à l'Empire. Nous avons également une piste qui nous mène à la cachette d'un vieux contrebandier sur Dévaron. Elle contient les cartes des meilleures routes de contrebande du secteur. Si nous arrivons à les obtenir, nous pourrons éviter les patrouilles Impériales et il nous sera même possible de nous passer des codes.\" Elle se tourne vers vous. \"Si vous pouvez nous aider à accomplir ces missions, j'enverrai un membre de mon équipage avec vous.\"\r\n\r\n{-} Les héros choisissent collectivement s'ils souhaitent aider Wolffe et Gregor ou s'ils préfèrent fouiller la cachette du contrebandier.\r\n{-} Si les héros choisissent d'aider Wolffe et Gregor, la prochaine mission active est \"Les Dunes de Seelos\".\r\n{-} Si les héros choisissent de fouiller la cachette du contrebandier, la prochaine mission active est \"Duel sur Dévaron\".",
+          "GUID": "a48da895-588c-40a5-ae8f-fa2b6a4da0b2",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        }
+      ]
+    },
+    {
+      "eventName": "No campaign",
+      "GUID": "8fe1b24a-487b-46a0-9e81-94329508e0dc",
+      "eventText": "{-} Chaque héros reçoit 1 XP.\r\n{-} Les héros reçoivent 100 crédits par héros.",
+      "eventActions": []
+    },
+    {
+      "eventName": "Droid Defeated 1",
+      "GUID": "9cb3b762-aece-40a2-9fb2-c6e9d8228221",
+      "eventText": "Le droïde blessé passe par la porte et la soude en toute hâte derrière lui. Si vous pouviez placer un traceur sur lui, vous sauriez où il emmène ses renseignements.\r\n\r\n{-} Une figurine peut interagir avec la porte ({K} ou {I}) pour essayer de l'ouvrir. Cette figurine peut subir 1 {C} durant ce test pour relancer n'importe quel nombre de dés.",
+      "eventActions": [
+        {
+          "shortText": "Quitter la planque.",
+          "longText": null,
+          "GUID": "9c247914-7a90-4349-8db0-a1ab0bad8a20",
+          "eventActionType": 2,
+          "eaName": "Change Objective"
+        },
+        {
+          "repositionText": "Bloquer l'accès à la porte.",
+          "GUID": "9ba6c090-b450-4432-a92d-38de74136647",
+          "eventActionType": 17,
+          "eaName": "Change Reposition Instructions"
+        },
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Door 1",
+              "GUID": "2d4a1911-00b0-4b33-a3cf-9c2da53c22e6",
+              "theText": "Une porte poussiéreuse mène à l'extérieur.",
+              "buttonList": [
+                {
+                  "GUID": "18a6c5e3-a3b3-43ef-9aa7-a1764bfe38f3",
+                  "theText": "{A} Essayer de l'ouvrir"
+                }
+              ]
+            }
+          ],
+          "GUID": "2de34cad-0b0a-436d-a492-25b42cc877f5",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "Call for Backup",
+      "GUID": "09ef7cb6-2c05-4e3d-a8eb-c7f5d403acdc",
+      "eventText": "Certains des hommes de main de Hondo semblent avoir été alertés par le pirate.",
+      "eventActions": []
+    },
+    {
+      "eventName": "Door Attempt",
+      "GUID": "84cfbc26-7755-44b4-a34e-0d7a223bf11c",
+      "eventText": "",
+      "eventActions": [
+        {
+          "mainText": "Vous essayez de forcer la porte.\r\n\r\n{-} Effectuez un test {K} ou {I}. Appliquez +1 {B} au test pour chaque pion Stress présent sur la porte, puis défaussez ces pions Stress. Entrez le nombre de réussites ci-dessous. Vous pouvez subir 1 {C} durant ce test pour relancer n'importe quel nombre de dés.",
+          "failText": "",
+          "inputList": [
+            {
+              "GUID": "3a941474-9892-4d62-b2e5-c9df849965e2",
+              "theText": "Vous faites quelques progrès, mais la porte reste fermée. Vous devez continuer à essayer.\r\n\r\n{-} Placez un pion Stress sur la porte pour chaque résultat {B}."
+            }
+          ],
+          "GUID": "5084bc4d-bfcc-474c-8ca0-becb20a74077",
+          "eventActionType": 20,
+          "eaName": "Input Prompt"
+        }
+      ]
+    },
+    {
+      "eventName": "Follow the Source",
+      "GUID": "2e09ffaf-3350-4d13-ab79-57aaf32de736",
+      "eventText": "La porte s'ouvre pour révéler le désert poussiéreux de Florrum.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "Door 1",
+              "GUID": "a6f6c888-a61b-4bc6-a45b-6674c39ed831",
+              "theText": "Une porte poussiéreuse mène à l'extérieur. Elle est verrouillée.",
+              "buttonList": []
+            },
+            {
+              "entityName": "DP Green 1",
+              "GUID": "0244dde3-3a83-40fc-b019-1e88bcfaaa56",
+              "theText": null,
+              "buttonList": []
+            },
+            {
+              "entityName": "DP Green 3",
+              "GUID": "53493470-9fe8-46a2-800c-c96eddef58a4",
+              "theText": null,
+              "buttonList": []
+            }
+          ],
+          "GUID": "4cff9923-5b0a-4942-b832-9f219a014829",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        },
+        {
+          "tbText": "Les ennemis vous attendent déjà.",
+          "GUID": "5c26fc15-941e-4706-9b89-3abcee988963",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "tbText": "À côté, vous voyez Hondo Ohnaka sourire en s'excusant. \"Je suis vraiment désolé, mes amis, mais je suis sûr que nous pourrons encore faire des affaires à l'avenir, non ?\", dit-il en dégainant son blaster.",
+          "GUID": "24fb31f1-398c-41a0-a390-4706f065f0ac",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "enemyName": null,
+          "customText": "",
+          "modification": "+*2* Santé",
+          "repositionInstructions": "",
+          "GUID": "67c65489-09d2-4e60-9416-b81482e8c845",
+          "eventActionType": 6,
+          "eaName": "Deploy: DG086/Hondo Ohnaka"
+        },
+        {
+          "tbText": "Le droïde infiltrateur se repose à proximité. Les protocoles de réparation se sont déjà occupé de la plupart des dommages. Ils ont même amélioré son armure.",
+          "GUID": "90bf9139-4221-4d0c-a34b-cadc10df4e6b",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "E-XD 2",
+              "GUID": "e5448568-e6ff-4165-8f74-ef110059d816",
+              "theText": null,
+              "buttonList": []
+            }
+          ],
+          "GUID": "4e89238c-20e4-454e-bcc5-905755bc1541",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        },
+        {
+          "GUID": "47e01a30-efc4-40ab-85e1-638a0acdf7d5",
+          "eventActionType": 21,
+          "eaName": "Custom Deployment: E-XD Infiltrator Droid",
+          "repositionInstructions": "",
+          "surges": "{B}: Perforant 2",
+          "bonuses": "GÉNÉRATEURS DE CHARGE: Cette figurine gagne 1 {h}.\nRÉPARATIONS AUTOMATIQUES: Cette figurine élimine 2 {H}.",
+          "keywords": "+5 Santé\r\n+4 Précision\r\n+1 {G}",
+          "abilities": "",
+          "customText": "{Q} Déplacement de 2 pour attaquer {rebel}.\r\n{A} Déplacement de 2 pour s'éloigner des Rebelles.\r\n{A} Déplacement de 4 pour s'éloigner des Rebelles.\r\n{-} Cette figurine gagne 1 {g}.",
+          "cardName": "Droïde Infiltrateur E-XD"
+        },
+        {
+          "tbText": "{-} Quand le E-XD est cense être vaincu, il est neutralisé à la place. \r\n{-} La mission évolue quand le E-XD est neutralisé.",
+          "GUID": "e40f3078-e413-48ed-b5e6-2349c2fb7983",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "repositionText": "Bloquer l'accès au droïde infiltrateur E-XD.",
+          "GUID": "61693b26-32ef-490b-8b06-b0eb8e317690",
+          "eventActionType": 17,
+          "eaName": "Change Reposition Instructions"
+        },
+        {
+          "shortText": "Vaincre le droïde infiltrateur E-XD une deuxième fois.",
+          "longText": null,
+          "GUID": "4be5304b-dd3a-4b52-b136-0d2a11103b4b",
+          "eventActionType": 2,
+          "eaName": "Change Objective"
+        },
+        {
+          "theText": "{-} Le pion Mission Impérial représente le droïde infiltrateur E-XD. \r\n{-} Quand le E-XD est cense être vaincu, il est neutralisé à la place. \r\n{-} La mission évolue quand le E-XD est neutralisé.\r\n{-} Les Rebelles perdent quand tous les héros sont blessés.",
+          "GUID": "aed1397f-051e-479c-97ac-9e94f1650b15",
+          "eventActionType": 1,
+          "eaName": "Change Mission Info"
+        },
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "E-XD 2",
+              "GUID": "d2c9018e-e792-4800-afc6-ee32dac1f453",
+              "theText": null,
+              "buttonList": []
+            }
+          ],
+          "GUID": "0ac9a7bc-0d8a-473e-8578-1d549b831e16",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        }
+      ]
+    },
+    {
+      "eventName": "Droid Defeated 2",
+      "GUID": "844e4120-d90d-452b-9fb7-2571996f8fc0",
+      "eventText": "Le droïde infiltrateur E-XD s'effondre, tel un tas de ferraille. Si vous arrivez à placer un traceur avant qu'il ne se répare de nouveau, vous pourrez le pister.",
+      "eventActions": [
+        {
+          "translatedEntityProperties": [
+            {
+              "entityName": "E-XD 3",
+              "GUID": "43289eea-3cd1-4a20-a7e1-275be25c5344",
+              "theText": "{-} Une figurine Rebelle peut interagir avec le E-XD neutralisé ({J}) pour essayer de placer dessus une balise de pistage. Quand la balise de pistage est placée, cliquez sur \"Placer une balise de pistage\".",
+              "buttonList": [
+                {
+                  "GUID": "c928ca86-9eae-421b-a93b-85576f7a4f5c",
+                  "theText": "{A} Placer une balise de pistage"
+                }
+              ]
+            }
+          ],
+          "GUID": "2540c8cb-faa3-4b12-9595-144bad6cf5e2",
+          "eventActionType": 15,
+          "eaName": "Modify Map Entity"
+        },
+        {
+          "tbText": "{-} Une figurine Rebelle peut interagir avec le E-XD neutralisé ({J}) pour essayer de placer dessus une balise de pistage. Cliquez alors sur le pion Mission situé hors du plateau et sélectionnez \"Placer une balise de pistage\".\r\n{-} Les Rebelles gagnent quand la balise de pistage est placée.",
+          "GUID": "b7b3087d-e977-40d4-b3b1-54b090891b33",
+          "eventActionType": 16,
+          "eaName": "Text Box"
+        },
+        {
+          "shortText": "Placer la balise de pistage.",
+          "longText": null,
+          "GUID": "d2e714e9-c56b-4c09-9b74-a0b3cc3bc508",
+          "eventActionType": 2,
+          "eaName": "Change Objective"
+        },
+        {
+          "theText": "{-} Le pion Mission Impérial représente le droïde infiltrateur E-XD neutralisé. \r\n{-} Une figurine Rebelle peut interagir avec le E-XD neutralisé ({J}) pour essayer de placer dessus une balise de pistage. Cliquez alors sur le pion Mission situé hors du plateau et sélectionnez \"Placer une balise de pistage\".\r\n{-} Les Rebelles gagnent quand la balise de pistage est placée.\r\n{-} Les Rebelles perdent quand tous les héros sont blessés.",
+          "GUID": "b058f822-e31d-47cb-899a-1dd61db5b7ea",
+          "eventActionType": 1,
+          "eaName": "Change Mission Info"
+        }
+      ]
+    },
+    {
+      "eventName": "Beacon attempt",
+      "GUID": "a2e7e7fb-6d85-4223-abbb-89c660f4de97",
+      "eventText": "",
+      "eventActions": [
+        {
+          "mainText": "Vous essayez de placer la balise de pistage dans un endroit où les systèmes du droïde ne la trouveront pas.\r\n\r\nEffectuez un test {J}. Appliquez +1 {B} au test pour chaque pion Stress présent sur E-XD, puis défaussez ces pions Stress. Entrez le nombre de réussites ci-dessous.",
+          "failText": "",
+          "inputList": [
+            {
+              "GUID": "7292ad87-86ca-4d35-a040-b416aa2fbe55",
+              "theText": "Vous ne trouvez pas d'emplacement approprié pour la balise."
+            }
+          ],
+          "GUID": "25cfc9b8-db28-4479-9eeb-877fb3543fcc",
+          "eventActionType": 20,
+          "eaName": "Input Prompt"
+        }
+      ]
+    }
+  ],
+  "mapEntities": [
+    {
+      "entityName": "Crate1",
+      "GUID": "dcf1e03e-e328-4f79-8427-e0a0bfc64f82",
+      "mainText": "Une vieille caisse de ravitaillement.",
+      "buttonList": [
+        {
+          "GUID": "0fa979f6-fb91-42ee-9c29-0a48d5df82ba",
+          "theText": "{A} Ouvrir"
+        }
+      ]
+    },
+    {
+      "entityName": "Crate2",
+      "GUID": "461e69e0-7c26-42a1-ad2a-a5e71b4f7707",
+      "mainText": "Une vieille caisse de ravitaillement.",
+      "buttonList": [
+        {
+          "GUID": "c332e66c-ec46-4d01-a753-3365c3c2e8fe",
+          "theText": "{A} Ouvrir"
+        }
+      ]
+    },
+    {
+      "entityName": "Crate3",
+      "GUID": "1e60bee2-7e72-4f71-8c0e-45b5a2d0baf8",
+      "mainText": "Une vieille caisse de ravitaillement.",
+      "buttonList": [
+        {
+          "GUID": "3a8866fd-5e86-47d9-b8f2-a8df9a58f32f",
+          "theText": "{A} Ouvrir"
+        }
+      ]
+    },
+    {
+      "entityName": "Entrance",
+      "GUID": "a343a128-3b10-48ff-878f-71c89176d776",
+      "mainText": "Déployer les héros ici.",
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Green 1",
+      "GUID": "c8062d94-a52f-4458-b2cf-3c7b515747e5",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Green 3",
+      "GUID": "64b4dbf2-4e39-4ce7-a5fe-94eed25c16d2",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Trando 1",
+      "GUID": "81ead058-7663-414c-aed5-13a096cc71f9",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Trando 2",
+      "GUID": "7e9021ad-ba7b-4a72-9f6a-58e1113bc9fc",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "Door 1",
+      "GUID": "0a6ea6c7-bc32-4abf-b7ff-d7a450dc916b",
+      "mainText": "Une porte poussiéreuse mène à l'extérieur. Elle est verrouillée.",
+      "buttonList": []
+    },
+    {
+      "entityName": "E-XD",
+      "GUID": "cdbd3f0f-9821-4bb5-a129-c1cb2419a459",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Blue 1",
+      "GUID": "7a5baa2d-d607-4955-91eb-7320301058cf",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Blue 2",
+      "GUID": "7c5f7bdc-83f6-4e26-b590-b4f7249adfeb",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Blue 3",
+      "GUID": "03f47c35-5ce4-4085-9c18-3622def07680",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Red",
+      "GUID": "a23cdb91-ebc1-4a81-9561-23b2fe9f39f5",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "DP Black",
+      "GUID": "0330dab6-0fa0-4f7a-8456-c55c76a40d51",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "E-XD 2",
+      "GUID": "a00ccdd1-4fe1-41aa-8732-87814ef1c8c1",
+      "mainText": null,
+      "buttonList": []
+    },
+    {
+      "entityName": "E-XD 3",
+      "GUID": "9ca16c10-5b9f-41a9-9bba-67a15641ff43",
+      "mainText": null,
+      "buttonList": []
+    }
+  ],
+  "initialGroups": [
+    {
+      "cardName": "Trandoshan Hunter",
+      "customInstructions": ""
+    }
+  ]
+}

--- a/ImperialCommander2/Assets/Resources/Languages/Fr/instructions.json
+++ b/ImperialCommander2/Assets/Resources/Languages/Fr/instructions.json
@@ -999,7 +999,7 @@
     "content": [
       {
         "instruction": [
-          "{-} ORDINATEUR DE VISÉE : Gagne +1 {H} and +2 Précision.",
+          "{-} ORDINATEUR DE VISÉE : Gagne +1 {H} et +2 Précision.",
           "{Q} Déplacement de 3 pour attaquer {R1}.",
           "{A} Déplacement de 2 pour engager le plus de Rebelles possibles (minimum 1).",
           "{-} Si adjacent à un Rebelle, mettre fin à cette activation.",
@@ -1268,7 +1268,7 @@
         "instruction": [
           "{Q} Déplacement de 3 pour attaquer {R1}.",
           "{A} Déplacement de 3 vers la figurine Impériale la plus proche.",
-          "{-} PATIENCE : Cette figurine et la figurine Impériale la plus proche avec le coût le plus élevé à X cases ou moins gagne 1 {h} and 1 {g}. X est égal au nombre de pions d'activation Rebelle épuisés.",
+          "{-} PATIENCE : Cette figurine et la figurine Impériale la plus proche avec le coût le plus élevé à X cases ou moins gagnent 1 {h} et 1 {g}. X est égal au nombre de pions d'activation Rebelle épuisés.",
           "{A} Déplacement de 5 pour se repositionner à 3."
         ]
       }

--- a/ImperialCommander2/Assets/Resources/Languages/Fr/ui.json
+++ b/ImperialCommander2/Assets/Resources/Languages/Fr/ui.json
@@ -126,7 +126,7 @@
     "fameIncreasedUC": "Vous avez gagné de la renommée",
     "noRandomMatchesUC": "Aucun groupe correspondant ayant un coût de {d} ou moins.",
     "depCostUC": "Coût de déploiement",
-    "noAbilitiesUC": "Aucune Capacité",
+    "noAbilitiesUC": "Aucune capacité",
     "ignoredAbilitiesUC": "Capacités de carte Ignorées",
     "noKeywordsUC": "Aucune",
     "noneUC": "Aucune",


### PR DESCRIPTION
This PR is purely FR translation related:

- Adding French translation for Lothal.
- Adding French translation for the 4 mission packs related Lothal extended campaign.
- Fixing a couple typos in ui.json and instructions.json.