### PR TITLE
Adding tiles translations and icons to the Info Popup

### DIFF
--- a/ImperialCommander2/Assets/Scripts/Saga/Managers/MissionEventHandler.cs
+++ b/ImperialCommander2/Assets/Scripts/Saga/Managers/MissionEventHandler.cs
@@ -695,7 +695,7 @@ namespace Saga
 				// Replacing tile expansion name with translated name
 				tilesWithCount = tilesWithCount.Select(x => { var name = x.Split(' ')[0]; return tileExpansionTranslatedNames.ContainsKey(name) ? x.Replace(name, tileExpansionTranslatedNames[name]) : x; }).ToList();
 				// If translated name is an expansion symbol, removing whitespace between symbol and tile number
-				tilesWithCount = tilesWithCount.Select(x => Regex.IsMatch(x, "\\{[0-6]+\\}") ? x.Replace("} ", "}") : x).ToList();
+				tilesWithCount = tilesWithCount.Select(x => Regex.IsMatch(x, "\\{[0-6]+\\}\\s") ? x.Replace("} ", "}") : x).ToList();
 
 				var tmsg = string.Join( ", ", tilesWithCount );
 				var emsg = DataStore.uiLanguage.sagaMainApp.mmAddEntitiesUC + ":\n\n";
@@ -728,7 +728,7 @@ namespace Saga
 				// Replacing tile expansion name with translated name
 				tiles = tiles.Select(x => { var name = x.Split(' ')[0]; return tileExpansionTranslatedNames.ContainsKey(name) ? x.Replace(name, tileExpansionTranslatedNames[name]) : x; }).ToList();
 				// If translated name is an expansion symbol, removing whitespace between symbol and tile number
-				tiles = tiles.Select(x => Regex.IsMatch(x, "\\{[0-6]+\\}") ? x.Replace("} ", "}") : x).ToList();
+				tiles = tiles.Select(x => Regex.IsMatch(x, "\\{[0-6]+\\}\\s") ? x.Replace("} ", "}") : x).ToList();
 
 				FindObjectOfType<TileManager>().CamToSection( mm.mapSectionRemove );
 				ShowTextBox( $"{DataStore.uiLanguage.sagaMainApp.mmRemoveTilesUC}:\n\n<color=orange>{string.Join( ", ", tiles )}</color>", () =>
@@ -745,7 +745,7 @@ namespace Saga
 				// Replacing tile expansion name with translated name
 				t = tileExpansionTranslatedNames.ContainsKey(name) ? t.Replace(name, tileExpansionTranslatedNames[name]) : t;
 				// If translated name is an expansion symbol, removing whitespace between symbol and tile number
-				t = Regex.IsMatch(t, "\\{[0-6]+\\}") ? t.Replace("} ", "}") : t;
+				t = Regex.IsMatch(t, "\\{[0-6]+\\}\\s") ? t.Replace("} ", "}") : t;
 
 				FindObjectOfType<TileManager>().CamToTile( mm.mapTile );
 				ShowTextBox( $"{DataStore.uiLanguage.sagaMainApp.mmAddTilesUC}:\n\n<color=orange>{t}</color>", () =>
@@ -762,7 +762,7 @@ namespace Saga
 				// Replacing tile expansion name with translated name
 				t = tileExpansionTranslatedNames.ContainsKey(name) ? t.Replace(name, tileExpansionTranslatedNames[name]) : t;
 				// If translated name is an expansion symbol, removing whitespace between symbol and tile number
-				t = Regex.IsMatch(t, "\\{[0-6]+\\}") ? t.Replace("} ", "}") : t;
+				t = Regex.IsMatch(t, "\\{[0-6]+\\}\\s") ? t.Replace("} ", "}") : t;
 
 				FindObjectOfType<TileManager>().CamToTile( mm.mapTileRemove );
 				ShowTextBox( $"{DataStore.uiLanguage.sagaMainApp.mmRemoveTilesUC}:\n\n<color=orange>{t}</color>", () =>

--- a/ImperialCommander2/Assets/Scripts/Screens/SagaController.cs
+++ b/ImperialCommander2/Assets/Scripts/Screens/SagaController.cs
@@ -502,7 +502,7 @@ namespace Saga
 				};
 
 				tilesWithCount = tilesWithCount.Select(x => { var name = x.Split(' ')[0]; return tileExpansionTranslatedNames.ContainsKey(name) ? x.Replace(name, tileExpansionTranslatedNames[name]) : x; }).ToList();
-				tilesWithCount = tilesWithCount.Select(x => Regex.IsMatch(x, "\\{[0-6]+\\}") ? x.Replace("} ", "}") : x).ToList();
+				tilesWithCount = tilesWithCount.Select(x => Regex.IsMatch(x, "\\{[0-6]+\\}\\s") ? x.Replace("} ", "}") : x).ToList();
 
 				var tmsg = string.Join( ", ", tilesWithCount );
 				var emsg = DataStore.uiLanguage.sagaMainApp.mmAddEntitiesUC + ":\n\n";

--- a/ImperialCommander2/Assets/Scripts/Screens/SetupScreen/TileInfoPopup.cs
+++ b/ImperialCommander2/Assets/Scripts/Screens/SetupScreen/TileInfoPopup.cs
@@ -1,4 +1,6 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
 using TMPro;
 using UnityEngine;
 using UnityEngine.EventSystems;
@@ -12,6 +14,17 @@ namespace Saga
 
 		public void Show( string[] tiles )
 		{
+			var tileExpansionTranslatedNames = new Dictionary<string, string>()
+				{
+					{ Expansion.Core.ToString(), $"{DataStore.uiLanguage.sagaMainApp.mmCoreTileNameUC}" },
+					{ Expansion.Twin.ToString(), $"{DataStore.uiLanguage.sagaMainApp.mmTwinTileNameUC}" },
+					{ Expansion.Hoth.ToString(), $"{DataStore.uiLanguage.sagaMainApp.mmHothTileNameUC}" },
+					{ Expansion.Bespin.ToString(), $"{DataStore.uiLanguage.sagaMainApp.mmBespinTileNameUC}" },
+					{ Expansion.Jabba.ToString(), $"{DataStore.uiLanguage.sagaMainApp.mmJabbaTileNameUC}" },
+					{ Expansion.Empire.ToString(), $"{DataStore.uiLanguage.sagaMainApp.mmEmpireTileNameUC}" },
+					{ Expansion.Lothal.ToString(), $"{DataStore.uiLanguage.sagaMainApp.mmLothalTileNameUC}" },
+				};
+
 			EventSystem.current.SetSelectedGameObject( null );
 			popupBase.Show();
 
@@ -47,14 +60,20 @@ namespace Saga
 				nt.alignment = TextAlignmentOptions.Center;
 				nt.horizontalAlignment = HorizontalAlignmentOptions.Left;
 
+				// Replacing tile expansion name with translated name
+				string expansionName = item.Tile.Split(' ')[0];
+				string itemTileTranslated = tileExpansionTranslatedNames.ContainsKey(expansionName) ? item.Tile.Replace(expansionName, tileExpansionTranslatedNames[expansionName]) : item.Tile;
+				// If translated name is an expansion symbol, removing whitespace between symbol and tile number
+				itemTileTranslated = Regex.IsMatch(itemTileTranslated, "\\{[0-6]+\\}\\s") ? itemTileTranslated.Replace("} ", "}") : itemTileTranslated;
+
 				// Display a count when more than one tile is needed
 				if (item.Count > 1 )
 				{
-					nt.text = $"{item.Tile} x {item.Count}";
+					nt.text = $"{Utils.ReplaceGlyphs(itemTileTranslated)} x {item.Count}";
 				}
 				else
 				{
-					nt.text = item.Tile;
+					nt.text = Utils.ReplaceGlyphs(itemTileTranslated);
 				}
 			}
 		}


### PR DESCRIPTION
This is a follow-up of https://github.com/GlowPuff/ImperialCommander2/pull/85 as it appears that I had missed 1 scenario (reported here: https://github.com/GlowPuff/ImperialCommander2/pull/85#issuecomment-2210325514).

- Adding tiles translations (and icons) to the Info Popup during missions setup.

- nit: I also updated the regex to be more coherent with the replace action.