### PR TITLE
FR translation: Adding translation for "Boons" in rewards

### DIFF
--- a/ImperialCommander2/Assets/Resources/Languages/Fr/CampaignData/rewards.json
+++ b/ImperialCommander2/Assets/Resources/Languages/Fr/CampaignData/rewards.json
@@ -33,25 +33,25 @@
     "id": "camp06",
     "name": "Galvanisés par la réussite",
     "type": 0,
-    "extra": "Boon"
+    "extra": "Bienfait"
   },
   {
     "id": "camp07",
     "name": "Réseaux rétablis",
     "type": 0,
-    "extra": "Boon"
+    "extra": "Bienfait"
   },
   {
     "id": "camp08",
     "name": "Renaissance",
     "type": 0,
-    "extra": "Boon"
+    "extra": "Bienfait"
   },
   {
     "id": "camp09",
     "name": "Stratégie mise en œuvre",
     "type": 0,
-    "extra": "Boon"
+    "extra": "Bienfait"
   },
   {
     "id": "general01",


### PR DESCRIPTION
PR purely FR translation related.

- translating "Boon" in rewards.

Note: it's contained in "extra" property.
It's not exposed by default in Translator app, so it's currently not translated in any language.
I pushed a PR for Translator App so that this "extra" property can be exposed and "Boon" can be translated to other languages.
See https://github.com/GlowPuff/SagaTranslatorModern/pull/6