### PR TITLE
Fixed typo in General Weiss instructions

### DIFF
--- a/ImperialCommander2/Assets/Resources/Languages/De/instructions.json
+++ b/ImperialCommander2/Assets/Resources/Languages/De/instructions.json
@@ -515,7 +515,7 @@
 			{
 				"instruction": [
 					"{Q} Bewegung 3, um {R1} anzugreifen.",
-					"{A} Wirf 1 gelben Würfel. Ein Rebell innerhalb von 3 Feldern erleidet {H} in Höhe der {H}-Ergebnisse und {C} in Höhe der {C}-Ergebnisse. Ziele auf den Helden, der die meisten {C} erlitten hat.",
+					"{A} Wirf 1 gelben Würfel. Ein Rebell innerhalb von 3 Feldern erleidet {H} in Höhe der {H}-Ergebnisse und {C} in Höhe der {B}-Ergebnisse. Ziele auf den Helden, der die meisten {C} erlitten hat.",
 					"{A} Bewegung 2, um in Position 2 zu gelangen.",
 					"{A} Bewegung 6, um in Position 2 zu gelangen.",
 					"{-} BEFEHL DES GENERALS: Die beiden anderen imperialen Figuren mit den höchsten Figurenkosten bewegen sich 2 auf den nächsten Rebellen zu und werden <color=\"red\">Fokussiert</color>.",

--- a/ImperialCommander2/Assets/Resources/Languages/En/instructions.json
+++ b/ImperialCommander2/Assets/Resources/Languages/En/instructions.json
@@ -515,7 +515,7 @@
 			{
 				"instruction": [
 					"{Q} Move 3 to attack {R1}.",
-					"{A} Roll 1 yellow die. A Rebel within 3 spaces suffers {H} equal to the {H} results and {C} equal to the {C} results. Target the hero who has suffered the least {C}.",
+					"{A} Roll 1 yellow die. A Rebel within 3 spaces suffers {H} equal to the {H} results and {C} equal to the {B} results. Target the hero who has suffered the least {C}.",
 					"{A} Move 2 to reposition 2.",
 					"{A} Move 6 to reposition 2.",
 					"{-} GENERAL’S ORDERS: The two other highest-cost Imperial figures move 2 towards the closest Rebel and become <color=\"red\">Focused</color>.",

--- a/ImperialCommander2/Assets/Resources/Languages/Es/instructions.json
+++ b/ImperialCommander2/Assets/Resources/Languages/Es/instructions.json
@@ -515,7 +515,7 @@
 			{
 				"instruction": [
 					"{Q} Mueve 3 para atacar a {R1}.",
-					"{A} Lanza 1 dado amarillo. Un Rebelde a 3 casillas sufres {H} igual a los resultados {H} y {C} igual a los resultados {C}. Objetivo el Héroe que haya sufrido menos {C}.",
+					"{A} Lanza 1 dado amarillo. Un Rebelde a 3 casillas sufres {H} igual a los resultados {H} y {C} igual a los resultados {B}. Objetivo el Héroe que haya sufrido menos {C}.",
 					"{A} Mueve 2 para reposicionar a 2.",
 					"{A} Mueve 6 para reposicionar a 2.",
 					"{-} ORDENES DEL GENERAL: Las otras dos figuras Imperiales de mayor coste mueven 2 hacia el Rebelde más cercano y adquieren Concentración.",

--- a/ImperialCommander2/Assets/Resources/Languages/Fr/instructions.json
+++ b/ImperialCommander2/Assets/Resources/Languages/Fr/instructions.json
@@ -515,7 +515,7 @@
       {
         "instruction": [
           "{Q} Déplacement de 3 pour attaquer {R1}.",
-          "{A} Lancer 1 dé jaune. Un Rebelle à 3 cases ou moins subit un nombre de {H} égal aux résultats {H} obtenus et subit aussi {C} égal aux résultats {C} obtenus. Cibler le Rebelle indemne qui a subi le moins de {C}.",
+          "{A} Lancer 1 dé jaune. Un Rebelle à 3 cases ou moins subit un nombre de {H} égal aux résultats {H} obtenus et subit aussi {C} égal aux résultats {B} obtenus. Cibler le Rebelle indemne qui a subi le moins de {C}.",
           "{A} Déplacement de 2 pour se repositionner à 2.",
           "{A} Déplacement de 6 pour se repositionner à 2.",
           "{-} ORDRES DU GÉNÉRAL : Les 2 autres figurines ayant le coût le plus élevé se déplacent de 2 vers le Rebelle le plus proche et deviennent <color=\"red\">Concentrées</color>."

--- a/ImperialCommander2/Assets/Resources/Languages/Hu/instructions.json
+++ b/ImperialCommander2/Assets/Resources/Languages/Hu/instructions.json
@@ -515,7 +515,7 @@
 			{
 				"instruction": [
 					"{Q} Mozogj 3 mezőt, hogy támadj {R1}.",
-					"{A} Roll 1 yellow die. A Rebel within 3 spaces suffers {H} equal to the {H} results and {C} equal to the {C} results. Target the hero who has suffered the least {C}.",
+					"{A} Roll 1 yellow die. A Rebel within 3 spaces suffers {H} equal to the {H} results and {C} equal to the {B} results. Target the hero who has suffered the least {C}.",
 					"{A} Mozogj 8 mezőt 2-es távolságra.",
 					"{A} Mozogj 6 mezőt 2-es távolságra.",
 					"{-} GENERAL’S ORDERS: The two other highest-cost Imperial figures move 2 towards the closest Rebel and become <color=\"red\">Focused</color>.",

--- a/ImperialCommander2/Assets/Resources/Languages/It/instructions.json
+++ b/ImperialCommander2/Assets/Resources/Languages/It/instructions.json
@@ -515,7 +515,7 @@
 			{
 				"instruction": [
 					"{Q} Muovi di 3 per attaccare {R1}.",
-					"{A} Tira 1 dado giallo. Un Ribelle entro 3 caselle subisce {H} pari al risultato {H} e {C} uguale al risultato {C}. Scegli come bersaglio l'eroe che ha subito meno {C}.",
+					"{A} Tira 1 dado giallo. Un Ribelle entro 3 caselle subisce {H} pari al risultato {H} e {C} uguale al risultato {B}. Scegli come bersaglio l'eroe che ha subito meno {C}.",
 					"{A} Muovi di 2 per riposizionare 2.",
 					"{A} Muovi di 6 per riposizionare 2.",
 					"{-} ORDINI DEL GENERALE: Le altre due miniature Imperiali dal costo di schieramento più alto si spostano di 2 caselle verso il Ribelle più vicino e diventano Concentrate.",

--- a/ImperialCommander2/Assets/Resources/Languages/No/instructions.json
+++ b/ImperialCommander2/Assets/Resources/Languages/No/instructions.json
@@ -515,7 +515,7 @@
 			{
 				"instruction": [
 					"{Q} Move 3 to attack {R1}.",
-					"{A} Roll 1 yellow die. A Rebel within 3 spaces suffers {H} equal to the {H} results and {C} equal to the {C} results. Target the hero who has suffered the least {C}.",
+					"{A} Roll 1 yellow die. A Rebel within 3 spaces suffers {H} equal to the {H} results and {C} equal to the {B} results. Target the hero who has suffered the least {C}.",
 					"{A} Move 2 to reposition 2.",
 					"{A} Move 6 to reposition 2.",
 					"{-} GENERAL’S ORDERS: The two other highest-cost Imperial figures move 2 towards the closest Rebel and become <color=\"red\">Focused</color>.",

--- a/ImperialCommander2/Assets/Resources/Languages/Pl/instructions.json
+++ b/ImperialCommander2/Assets/Resources/Languages/Pl/instructions.json
@@ -516,7 +516,7 @@
 			{
 				"instruction": [
 					"{Q} Porusz o 3 aby wykonać atak na {R1}.",
-					"{A} Rzuć 1 żółtą kością. Figurka Rebelii w promieniu 3 pól otrzymuje {H} równe wynikom {H} i {C} równe wynikom {C}. Celuj w bohatera z najmniejszą liczbą {C}.",
+					"{A} Rzuć 1 żółtą kością. Figurka Rebelii w promieniu 3 pól otrzymuje {H} równe wynikom {H} i {C} równe wynikom {B}. Celuj w bohatera z najmniejszą liczbą {C}.",
 					"{A} Porusz o 2 aby oddalić się o 2.",
 					"{A} Porusz o 6 aby oddalić się o 2.",
 					"{-} ROZKAZY GENERAŁA: Dwie inne figurki Imperium o największym koszcie rozstawienia poruszają się o 2 w kierunku najbliższego sobie Rebelianta i Skupiają się.",


### PR DESCRIPTION
This fixes the typo reported by ilujito in issue #109.