### PR TITLE
Fixing ordering missions in the popup window when expansion is changed

### DIFF
--- a/ImperialCommander2/Assets/Scripts/Screens/CampaignScreen/AddCampaignItemPopup.cs
+++ b/ImperialCommander2/Assets/Scripts/Screens/CampaignScreen/AddCampaignItemPopup.cs
@@ -220,7 +220,7 @@ namespace Saga
 			else
 			{
 				//default behavior in every other case, show missions from initially selected expansion in the dropdown (selectedExpansion)
-				foreach ( var item in DataStore.missionCards[selectedExpansion].OrderBy(x => x.name).OrderBy(x => x.missionType[0]).ToList())
+				foreach ( var item in DataStore.missionCards[selectedExpansion].OrderBy(x => x.name).OrderBy(x => x.missionType[0]).ToList() )
 				{
 					var go = Instantiate( itemSkillSelectorPrefab, itemContainer );
 					go.GetComponent<ItemSkillSelectorPrefab>().Init( item );
@@ -316,7 +316,7 @@ namespace Saga
 			//official missions
 			if ( selectedExpansion != "Custom" && selectedExpansion != "Embedded" )
 			{
-				foreach ( var card in DataStore.missionCards[selectedExpansion] )
+				foreach ( var item in DataStore.missionCards[selectedExpansion].OrderBy(x => x.name).OrderBy(x => x.missionType[0]).ToList() )
 				{
 					var go = Instantiate( itemSkillSelectorPrefab, itemContainer );
 					go.GetComponent<ItemSkillSelectorPrefab>().Init( card );

--- a/ImperialCommander2/Assets/Scripts/Screens/CampaignScreen/AddCampaignItemPopup.cs
+++ b/ImperialCommander2/Assets/Scripts/Screens/CampaignScreen/AddCampaignItemPopup.cs
@@ -316,7 +316,7 @@ namespace Saga
 			//official missions
 			if ( selectedExpansion != "Custom" && selectedExpansion != "Embedded" )
 			{
-				foreach ( var item in DataStore.missionCards[selectedExpansion].OrderBy(x => x.name).OrderBy(x => x.missionType[0]).ToList() )
+				foreach ( var card in DataStore.missionCards[selectedExpansion].OrderBy(x => x.name).OrderBy(x => x.missionType[0]).ToList() )
 				{
 					var go = Instantiate( itemSkillSelectorPrefab, itemContainer );
 					go.GetComponent<ItemSkillSelectorPrefab>().Init( card );


### PR DESCRIPTION
Follow-up of https://github.com/GlowPuff/ImperialCommander2/pull/107

I missed a scenario : when mission were changed in the popup window.
This PR is adding this scenario.