### PR TITLE
Campaign setup improvements

### DIFF
--- a/ImperialCommander2/Assets/Scripts/Screens/CampaignManager.cs
+++ b/ImperialCommander2/Assets/Scripts/Screens/CampaignManager.cs
@@ -302,6 +302,22 @@ namespace Saga
 				sc.UpdateCreditsUI( RunningCampaign.sagaCampaign.credits + item.cost );
 				sc.sound.PlaySound( 1 );
 
+				//remove item from hero items as well
+				foreach (var hero in sagaCampaign.campaignHeroes)
+				{
+					if (hero.campaignItems.Any(x => x.id == item.id))
+					{
+						hero.campaignItems.Remove(item);
+
+						int c = sagaCampaign.campaignHeroes.Count;
+						for (int i = 0; i < c; i++)
+						{
+							if (sagaCampaign.campaignHeroes[i].heroID == hero.heroID)
+								heroPrefabs[i].AddHeroToUI(sagaCampaign.campaignHeroes[i]);
+						}
+					}
+				}
+
 				sagaCampaign.campaignItems.Remove( item.id );
 				Destroy( go );
 			} );

--- a/ImperialCommander2/Assets/Scripts/Screens/CampaignManager.cs
+++ b/ImperialCommander2/Assets/Scripts/Screens/CampaignManager.cs
@@ -307,7 +307,7 @@ namespace Saga
 				{
 					if (hero.campaignItems.Any(x => x.id == item.id))
 					{
-						hero.campaignItems.Remove(item);
+						hero.campaignItems.Remove(hero.campaignItems.Where(x => x.id == item.id).First());
 
 						int c = sagaCampaign.campaignHeroes.Count;
 						for (int i = 0; i < c; i++)

--- a/ImperialCommander2/Assets/Scripts/Screens/CampaignManager.cs
+++ b/ImperialCommander2/Assets/Scripts/Screens/CampaignManager.cs
@@ -186,13 +186,18 @@ namespace Saga
 			awardsWheel.ResetWheeler( sagaCampaign.awards );
 
 			//items
-			foreach ( var item in sagaCampaign.campaignItems )
-				AddItemToUI( sagaCampaign.GetItemFromID( item ) );
+			Dictionary<string, string> items = new Dictionary<string, string>();
+			foreach (var campaignItem in sagaCampaign.campaignItems)
+			{
+				items.Add(campaignItem, SagaCampaign.campaignDataItems.First(x => x.id == campaignItem).name);
+			}
+			foreach ( var item in items.OrderBy(x => x.Value) )
+				AddItemToUI( sagaCampaign.GetItemFromID( item.Key ) );
 			//allies
-			foreach ( var ally in sagaCampaign.campaignAllies )
+			foreach ( var ally in sagaCampaign.campaignAllies.OrderBy(x => x.name) )
 				AddAllyToUI( ally );
 			//villains
-			foreach ( var villain in sagaCampaign.campaignVillains )
+			foreach ( var villain in sagaCampaign.campaignVillains.OrderBy(x => x.name) )
 				AddVillainToUI( villain );
 			//heroes
 			int c = sagaCampaign.campaignHeroes.Count;
@@ -202,8 +207,13 @@ namespace Saga
 				heroPrefabs[i].mWheelHandler.valueAdjuster = valueAdjuster;
 			}
 			//rewards
-			foreach ( var item in sagaCampaign.campaignRewards )
-				AddRewardToUI( sagaCampaign.GetRewardFromID( item ) );
+			Dictionary<string, string> rewards = new Dictionary<string, string>();
+			foreach (var campaignReward in sagaCampaign.campaignRewards)
+			{
+				rewards.Add(campaignReward, SagaCampaign.campaignDataRewards.First(x => x.id == campaignReward).name);
+			}
+			foreach ( var reward in rewards.OrderBy(x => x.Value))
+				AddRewardToUI( sagaCampaign.GetRewardFromID( reward.Key) );
 			//campaign structure
 			foreach ( Transform item in structureContainer )
 				Destroy( item.gameObject );
@@ -236,7 +246,13 @@ namespace Saga
 				return;
 			}
 
+			var index = sagaCampaign.campaignAllies.OrderBy(x => x.name).ToList().FindIndex(x => x.name == a.name);
+
 			var go = Instantiate( listItemPrefab, allyContainer );
+
+			if (index < allyContainer.childCount)
+				go.transform.SetSiblingIndex(index);
+
 			go.GetComponent<CampaignListItemPrefab>().InitAlly( a.name, ( n ) =>
 			{
 				sagaCampaign.campaignAllies.Remove( a );
@@ -252,7 +268,13 @@ namespace Saga
 				return;
 			}
 
+			var index = sagaCampaign.campaignVillains.OrderBy(x => x.name).ToList().FindIndex(x => x.name == v.name);
+
 			var go = Instantiate( listItemPrefab, villainContainer );
+
+			if (index < villainContainer.childCount)
+				go.transform.SetSiblingIndex(index);
+
 			go.GetComponent<CampaignListItemPrefab>().InitVillain( v.name, ( n ) =>
 			{
 				sagaCampaign.campaignVillains.Remove( v );
@@ -262,7 +284,17 @@ namespace Saga
 
 		void AddItemToUI( CampaignItem item, bool showCoinIcon = false )
 		{
+			List<string> items = new List<string>();
+			foreach (var campaignItem in sagaCampaign.campaignItems)
+				items.Add(SagaCampaign.campaignDataItems.First(x => x.id == campaignItem).name);
+
+			var index = items.OrderBy(x => x).ToList().FindIndex(x => x == item.name);
+
 			var go = Instantiate( listItemPrefab, itemContainer );
+
+			if (index < itemContainer.childCount)
+				go.transform.SetSiblingIndex(index);
+
 			go.GetComponent<CampaignListItemPrefab>().InitGeneralItem( item.name, ( n ) =>
 			{
 				//add item cost back to credits
@@ -277,7 +309,17 @@ namespace Saga
 
 		void AddRewardToUI( CampaignReward item )
 		{
+			List<string> rewards = new List<string>();
+			foreach (var campaignReward in sagaCampaign.campaignRewards)
+				rewards.Add(SagaCampaign.campaignDataRewards.First(x => x.id == campaignReward).name);
+
+			var index = rewards.OrderBy(x => x).ToList().FindIndex(x => x == item.name);
+
 			var go = Instantiate( listItemPrefab, rewardContainer );
+
+			if (index < rewardContainer.childCount)
+				go.transform.SetSiblingIndex(index);
+
 			go.GetComponent<CampaignListItemPrefab>().InitGeneralItem( item.name, ( n ) =>
 			{
 				sagaCampaign.campaignRewards.Remove( item.id );

--- a/ImperialCommander2/Assets/Scripts/Screens/CampaignScreen/AddCampaignItemPopup.cs
+++ b/ImperialCommander2/Assets/Scripts/Screens/CampaignScreen/AddCampaignItemPopup.cs
@@ -119,8 +119,11 @@ namespace Saga
 
 			foreach ( var item in skills.Where( x => x.owner == heroID ).OrderBy(x => x.name).OrderBy(x => x.cost) )
 			{
-				var go = Instantiate( itemSkillSelectorPrefab, itemContainer );
-				go.GetComponent<ItemSkillSelectorPrefab>().Init( item, heroID );
+				if (!sagaCampaign.campaignHeroes.Where(x => x.heroID == heroID).First().campaignSkills.Any(x => x.id == item.id))
+				{
+					var go = Instantiate(itemSkillSelectorPrefab, itemContainer);
+					go.GetComponent<ItemSkillSelectorPrefab>().Init(item, heroID);
+				}
 			}
 
 			addSkillCallback = callback;

--- a/ImperialCommander2/Assets/Scripts/Screens/CampaignScreen/AddCampaignItemPopup.cs
+++ b/ImperialCommander2/Assets/Scripts/Screens/CampaignScreen/AddCampaignItemPopup.cs
@@ -57,7 +57,7 @@ namespace Saga
 			//add global imports, omitting those already added to compaign
 			h = h.Concat( DataStore.globalImportedCharacters.Where( x => x.deploymentCard.characterType == CharacterType.Hero && !ch.Contains( x.deploymentCard.id ) ).Select( x => x.deploymentCard ) );
 
-			foreach ( var item in h )
+			foreach ( var item in h.OrderBy(x => x.name) )
 			{
 				var go = Instantiate( toonPrefab, itemContainer );
 				go.GetComponent<ToonSelectorPrefab>().InitHero( item );
@@ -77,7 +77,7 @@ namespace Saga
 			//add global imports
 			var allies = DataStore.allyCards.Concat( DataStore.globalImportedCharacters.Where( x => x.deploymentCard.characterType == CharacterType.Ally ).Select( x => x.deploymentCard ) ).Where( x => !sc.Contains( x ) ).ToList();
 
-			foreach ( var item in allies )
+			foreach ( var item in allies.OrderBy(x => x.name) )
 			{
 				var go = Instantiate( toonPrefab, itemContainer );
 				go.GetComponent<ToonSelectorPrefab>().InitAlly( item );
@@ -98,7 +98,7 @@ namespace Saga
 			var villains = DataStore.villainCards.Concat( DataStore.globalImportedCharacters.Where( x => x.deploymentCard.characterType == CharacterType.Villain ).Select( x => x.deploymentCard ) ).Where( x => !sc.Contains( x ) ).ToList();
 
 			//omit villains already added to campaign
-			foreach ( var item in villains )
+			foreach ( var item in villains.OrderBy(x => x.name) )
 			{
 				var go = Instantiate( toonPrefab, itemContainer );
 				go.GetComponent<ToonSelectorPrefab>().InitVillain( item );
@@ -117,7 +117,7 @@ namespace Saga
 
 			var skills = SagaCampaign.campaignDataSkills.Concat( DataStore.globalImportedCharacters.Where( x => x.deploymentCard.characterType == CharacterType.Hero ).SelectMany( x => x.heroSkills ) );
 
-			foreach ( var item in skills.Where( x => x.owner == heroID ) )
+			foreach ( var item in skills.Where( x => x.owner == heroID ).OrderBy(x => x.name).OrderBy(x => x.cost) )
 			{
 				var go = Instantiate( itemSkillSelectorPrefab, itemContainer );
 				go.GetComponent<ItemSkillSelectorPrefab>().Init( item, heroID );

--- a/ImperialCommander2/Assets/Scripts/Screens/CampaignScreen/CampaignHeroPrefab.cs
+++ b/ImperialCommander2/Assets/Scripts/Screens/CampaignScreen/CampaignHeroPrefab.cs
@@ -115,7 +115,7 @@ namespace Saga
 			//skills
 			var skills = SagaCampaign.campaignDataSkills.Concat( DataStore.globalImportedCharacters.Where( x => x.deploymentCard.characterType == CharacterType.Hero ).SelectMany( x => x.heroSkills ) );
 
-			foreach ( var skill in campaignHero.campaignSkills )
+			foreach ( var skill in campaignHero.campaignSkills.OrderBy(x => x.name) )
 			{
 				var go = Instantiate( listItem, contentContainer );
 				string s = skills.Where( x => x.id == skill.id ).First().name;
@@ -128,7 +128,7 @@ namespace Saga
 				} );
 			}
 			//items
-			foreach ( var item in campaignHero.campaignItems )
+			foreach ( var item in campaignHero.campaignItems.OrderBy(x => x.name) )
 			{
 				var go = Instantiate( listItem, contentContainer );
 				string s = SagaCampaign.campaignDataItems.Where( x => x.id == item.id ).First().name;

--- a/ImperialCommander2/Assets/Scripts/Screens/CampaignScreen/ItemSkillSelectorPrefab.cs
+++ b/ImperialCommander2/Assets/Scripts/Screens/CampaignScreen/ItemSkillSelectorPrefab.cs
@@ -25,9 +25,27 @@ namespace Saga
 		{
 			itemType = 0;
 			campaignItem = item;
-			nameText.text = $"{item.name} / <color=orange>{DataStore.uiLanguage.uiCampaign.tierUC} {item.tier}</color>";
 			typeText.text = item.type;
-			costText.text = $"{DataStore.uiLanguage.uiCampaign.costUC}: {item.cost}";
+
+			bool itemAlreadyAssigned = false;
+			foreach (var campaignHero in FindObjectOfType<CampaignManager>().sagaCampaign.campaignHeroes)
+			{
+				if (campaignHero.campaignItems.Any(x => x.id == item.id) )
+					itemAlreadyAssigned = true;
+			}
+
+			if (!itemAlreadyAssigned)
+			{
+				nameText.text = $"{item.name} / <color=orange>{DataStore.uiLanguage.uiCampaign.tierUC} {item.tier}</color>";
+				costText.text = $"{DataStore.uiLanguage.uiCampaign.costUC}: {item.cost}";
+			}
+			else //item is already assigned to one of the heroes
+			{
+				nameText.text = $"<color=grey>{item.name} / {DataStore.uiLanguage.uiCampaign.tierUC} {item.tier}</color>";
+				costText.text = $"<color=grey>{DataStore.uiLanguage.uiCampaign.costUC}: {item.cost}</color>";
+				addButton.interactable = false;
+			}
+
 			plusObject.SetActive( !showCoinIcon );
 			cointObject.SetActive( showCoinIcon );
 			usingCoins = showCoinIcon;


### PR DESCRIPTION
Proposing several changes in this PR.
All these changes are to improve the end user experience in the Campaign Setup menu:

- Ordering Heroes name in Hero selection menu
- Ordering Skills and Items on Hero sum-up (campaign screen) (note: Skills are still in 1 block at the top, all Items after)
- When adding an item to a hero, the item selection pop-up will now show items already assigned to a hero in grey, "add" button being disabled (this way you cannot add the same item to 2 heroes)
- When adding a skill to a hero, hiding the skills already bought
- Ordering Items in item sum-up (campaign screen)
- When removing an Item from the party item list sum-up (campaign screen), it also automatically removes it from a hero if it was assigned to that hero
- Ordering Rewards in rewards sum-up (campaign screen)
- Ordering Villains name in Villains selection menu
- Ordering Villains in villains sum-up (campaign screen)
- Ordering Allies  name in Allies selection menu
- Ordering Allies in allies sum-up (campaign screen)

All these changes will apply to all languages.

----------------------

Example for:

- Ordering Skills and Items on Hero sum-up (campaign screen) (note: Skills are still in 1 block at the top, all Items after)
- Ordering Items in item sum-up (campaign screen)
- Ordering Rewards in rewards sum-up (campaign screen)
- Ordering Villains in villains sum-up (campaign screen)
- Ordering Allies in allies sum-up (campaign screen)

Before:
![image](https://github.com/user-attachments/assets/5e34260a-5112-4c4c-b6a9-f92ccd301b40)

After:
![image](https://github.com/user-attachments/assets/d2d4a84e-9b90-4972-bd35-8033c1b44ec2)

----------------------

Example for:
- Ordering Heroes name in Hero selection menu
- Ordering Villains name in Villains selection menu
- Ordering Allies name in Allies selection menu

![image](https://github.com/user-attachments/assets/0cf347ad-0b48-42c3-a669-e3454cb4df78)

![image](https://github.com/user-attachments/assets/74f4c40c-3220-49d5-a906-9c1319a287fb)

![image](https://github.com/user-attachments/assets/a276ac3e-e1e3-4be7-a516-47ac1b4d6b6d)

----------------------

Example for:
- When adding an item to a hero, the item selection pop-up will now show items already assigned to a hero in grey, "add" button being disabled (this way you cannot add the same item to 2 heroes)

![image](https://github.com/user-attachments/assets/a8267f60-d507-4604-b26f-5da3c7ccfb09)

----------------------

Example for:
- When adding a skill to a hero, not displaying the skills already bought

![image](https://github.com/user-attachments/assets/e13a84d1-9417-4c82-9979-bf08c62bb86e)

----------------------

Example for:
- When removing an Item from the party item list sum-up (campaign screen), it also automatically removes it from a hero if it was assigned to that hero

Before:
![image](https://github.com/user-attachments/assets/851a6cc2-97ea-4fde-bed7-887f854c3290)

After:
![image](https://github.com/user-attachments/assets/8283da45-08b2-485b-b81e-a929692d6227)

