### PR TITLE
Fixing Crates in Empire15 & Empire16

### DIFF
--- a/ImperialCommander2/Assets/Resources/SagaMissions/Empire/EMPIRE15.json
+++ b/ImperialCommander2/Assets/Resources/SagaMissions/Empire/EMPIRE15.json
@@ -2,8 +2,8 @@
   "missionGUID": "8c04e521-a0b0-41e5-933c-9a465abf5743",
   "fileName": "EMPIRE15.json",
   "fileVersion": "22",
-  "saveDate": "4/26/2024",
-  "timeTicks": 638497441902303007,
+  "saveDate": "7/25/2024",
+  "timeTicks": 638574663573900458,
   "languageID": "English (EN)",
   "missionProperties": {
     "missionName": "Test of Metal",
@@ -19,7 +19,6 @@
     "optionalDeployment": false,
     "factionImperial": true,
     "factionMercenary": true,
-    "useAlternateEventSystem": false,
     "roundLimit": 6,
     "useFixedAlly": 1,
     "useBannedAlly": 1,
@@ -30,6 +29,7 @@
     "priorityOther": "",
     "startingEvent": "edc56ae0-7e4f-4ecd-9176-26e69bfd835a",
     "roundLimitEvent": "9e960fce-d271-468c-8d6c-233bc752aa52",
+    "useAlternateEventSystem": false,
     "missionType": 1,
     "changeRepositionOverride": {
       "theText": "Block access to the terminals.",
@@ -547,6 +547,24 @@
           "GUID": "8eb6c4bb-fd64-4ae8-9b6d-a5ba3f737e6a",
           "eventActionType": 15,
           "displayName": "Modify Map Entity"
+        },
+        {
+          "creditsToModify": 50,
+          "multiplyByHeroCount": false,
+          "GUID": "6620d4da-9c76-4c39-b246-04718dfec94f",
+          "eventActionType": 25,
+          "displayName": "Modify Credits"
+        },
+        {
+          "campaignItems": [],
+          "campaignRewards": [],
+          "earnedVillains": [],
+          "earnedAllies": [],
+          "medpacsToModify": 1,
+          "threatToModify": 0,
+          "GUID": "fa1ab406-317f-4712-a307-84377c5b6b3f",
+          "eventActionType": 30,
+          "displayName": "Add Campaign Reward"
         }
       ]
     },
@@ -597,6 +615,24 @@
           "GUID": "a6f06d59-b18c-465a-acc1-85db4a122e25",
           "eventActionType": 15,
           "displayName": "Modify Map Entity"
+        },
+        {
+          "creditsToModify": 50,
+          "multiplyByHeroCount": false,
+          "GUID": "60e00f59-910f-4972-8357-94488d8298f1",
+          "eventActionType": 25,
+          "displayName": "Modify Credits"
+        },
+        {
+          "campaignItems": [],
+          "campaignRewards": [],
+          "earnedVillains": [],
+          "earnedAllies": [],
+          "medpacsToModify": 1,
+          "threatToModify": 0,
+          "GUID": "3bebbdb3-fac9-4862-b883-9c81c75def76",
+          "eventActionType": 30,
+          "displayName": "Add Campaign Reward"
         }
       ]
     },
@@ -647,6 +683,24 @@
           "GUID": "50b5bf42-216f-45db-925e-d733f34fdd76",
           "eventActionType": 15,
           "displayName": "Modify Map Entity"
+        },
+        {
+          "creditsToModify": 50,
+          "multiplyByHeroCount": false,
+          "GUID": "2a0a49c1-77e9-4e8e-8cf8-953eeb6138dc",
+          "eventActionType": 25,
+          "displayName": "Modify Credits"
+        },
+        {
+          "campaignItems": [],
+          "campaignRewards": [],
+          "earnedVillains": [],
+          "earnedAllies": [],
+          "medpacsToModify": 1,
+          "threatToModify": 0,
+          "GUID": "cc9b92b0-aea9-47d1-80cf-14e4fab9a6a0",
+          "eventActionType": 30,
+          "displayName": "Add Campaign Reward"
         }
       ]
     },

--- a/ImperialCommander2/Assets/Resources/SagaMissions/Empire/EMPIRE16.json
+++ b/ImperialCommander2/Assets/Resources/SagaMissions/Empire/EMPIRE16.json
@@ -2,8 +2,8 @@
   "missionGUID": "08b73add-4288-45fc-804d-6e0eff81bf68",
   "fileName": "EMPIRE16.json",
   "fileVersion": "22",
-  "saveDate": "4/26/2024",
-  "timeTicks": 638497441902379653,
+  "saveDate": "7/25/2024",
+  "timeTicks": 638574662714065789,
   "languageID": "English (EN)",
   "missionProperties": {
     "missionName": "Unfinished Business",
@@ -19,7 +19,6 @@
     "optionalDeployment": false,
     "factionImperial": true,
     "factionMercenary": true,
-    "useAlternateEventSystem": false,
     "roundLimit": 6,
     "useFixedAlly": 1,
     "useBannedAlly": 1,
@@ -30,6 +29,7 @@
     "priorityOther": "",
     "startingEvent": "edc56ae0-7e4f-4ecd-9176-26e69bfd835a",
     "roundLimitEvent": "9e960fce-d271-468c-8d6c-233bc752aa52",
+    "useAlternateEventSystem": false,
     "missionType": 1,
     "changeRepositionOverride": {
       "theText": "Block access to explosives, terminals, and doors.",
@@ -466,6 +466,24 @@
           "GUID": "8eb6c4bb-fd64-4ae8-9b6d-a5ba3f737e6a",
           "eventActionType": 15,
           "displayName": "Modify Map Entity"
+        },
+        {
+          "creditsToModify": 50,
+          "multiplyByHeroCount": false,
+          "GUID": "039ee261-3b72-4da6-8b2b-3af035ab2425",
+          "eventActionType": 25,
+          "displayName": "Modify Credits"
+        },
+        {
+          "campaignItems": [],
+          "campaignRewards": [],
+          "earnedVillains": [],
+          "earnedAllies": [],
+          "medpacsToModify": 1,
+          "threatToModify": 0,
+          "GUID": "d66bcd39-71c1-4796-af5b-23662e74c0a2",
+          "eventActionType": 30,
+          "displayName": "Add Campaign Reward"
         }
       ]
     },
@@ -516,6 +534,24 @@
           "GUID": "a6f06d59-b18c-465a-acc1-85db4a122e25",
           "eventActionType": 15,
           "displayName": "Modify Map Entity"
+        },
+        {
+          "creditsToModify": 50,
+          "multiplyByHeroCount": false,
+          "GUID": "3d27e6d6-ba35-4355-9873-3914f7028052",
+          "eventActionType": 25,
+          "displayName": "Modify Credits"
+        },
+        {
+          "campaignItems": [],
+          "campaignRewards": [],
+          "earnedVillains": [],
+          "earnedAllies": [],
+          "medpacsToModify": 1,
+          "threatToModify": 0,
+          "GUID": "286dbe54-bb6c-4569-a943-0f016d19e620",
+          "eventActionType": 30,
+          "displayName": "Add Campaign Reward"
         }
       ]
     },
@@ -566,6 +602,24 @@
           "GUID": "50b5bf42-216f-45db-925e-d733f34fdd76",
           "eventActionType": 15,
           "displayName": "Modify Map Entity"
+        },
+        {
+          "creditsToModify": 50,
+          "multiplyByHeroCount": false,
+          "GUID": "9831a3e1-d13c-4927-b0d5-d93d260ef54b",
+          "eventActionType": 25,
+          "displayName": "Modify Credits"
+        },
+        {
+          "campaignItems": [],
+          "campaignRewards": [],
+          "earnedVillains": [],
+          "earnedAllies": [],
+          "medpacsToModify": 1,
+          "threatToModify": 0,
+          "GUID": "3b94c29c-fa10-4bc9-8e2f-a8290601b857",
+          "eventActionType": 30,
+          "displayName": "Add Campaign Reward"
         }
       ]
     },
@@ -623,6 +677,24 @@
           "GUID": "5d3f9806-368e-4034-981d-86ca38608ffb",
           "eventActionType": 15,
           "displayName": "Modify Map Entity"
+        },
+        {
+          "creditsToModify": 50,
+          "multiplyByHeroCount": false,
+          "GUID": "34a7a429-5399-4883-bf14-e49c31ea42aa",
+          "eventActionType": 25,
+          "displayName": "Modify Credits"
+        },
+        {
+          "campaignItems": [],
+          "campaignRewards": [],
+          "earnedVillains": [],
+          "earnedAllies": [],
+          "medpacsToModify": 1,
+          "threatToModify": 0,
+          "GUID": "016e520b-23ee-4726-a64e-3dd63053db75",
+          "eventActionType": 30,
+          "displayName": "Add Campaign Reward"
         }
       ]
     },


### PR DESCRIPTION
Fixing Crates in Empire 15 & 16, so that credits and medpacs are added automatically during the mission.