### PR TITLE
Proposing to remove automatically selected mission when there are multiple Story missions

### DIFF
--- a/ImperialCommander2/Assets/Resources/SagaMissions/Empire/EMPIRE2.json
+++ b/ImperialCommander2/Assets/Resources/SagaMissions/Empire/EMPIRE2.json
@@ -824,13 +824,6 @@
           "displayName": "Modify Credits"
         },
         {
-          "customMissionID": "",
-          "missionID": "empire6",
-          "GUID": "e73e600d-c27e-4db6-8ee3-e1ac6d2545a4",
-          "eventActionType": 27,
-          "displayName": "Set Next Mission"
-        },
-        {
           "theText": "Is there only 1 healthy hero?",
           "includeCancel": false,
           "buttonList": [
@@ -904,13 +897,6 @@
           "GUID": "bb944558-84b5-421d-9c97-3f65eceb0ad5",
           "eventActionType": 25,
           "displayName": "Modify Credits"
-        },
-        {
-          "customMissionID": "",
-          "missionID": "empire6",
-          "GUID": "8aad8897-77a4-4aa0-a594-2e9a2240383e",
-          "eventActionType": 27,
-          "displayName": "Set Next Mission"
         },
         {
           "incRoundCounter": false,

--- a/ImperialCommander2/Assets/Resources/SagaMissions/Jabba/JABBA10.json
+++ b/ImperialCommander2/Assets/Resources/SagaMissions/Jabba/JABBA10.json
@@ -1005,13 +1005,6 @@
           "displayName": "Modify Credits"
         },
         {
-          "customMissionID": "",
-          "missionID": "jabba8",
-          "GUID": "182f91cf-54ce-4e6c-b90c-02fcb67360b4",
-          "eventActionType": 27,
-          "displayName": "Set Next Mission"
-        },
-        {
           "incRoundCounter": false,
           "pauseDeployment": false,
           "unpauseDeployment": false,
@@ -1070,13 +1063,6 @@
           "GUID": "c02c097f-1857-4ef8-bcda-b76a368e11d8",
           "eventActionType": 25,
           "displayName": "Modify Credits"
-        },
-        {
-          "customMissionID": "",
-          "missionID": "jabba8",
-          "GUID": "eb692927-f167-4705-a090-cc30acbd6480",
-          "eventActionType": 27,
-          "displayName": "Set Next Mission"
         },
         {
           "incRoundCounter": false,

--- a/ImperialCommander2/Assets/Resources/SagaMissions/Jabba/JABBA5.json
+++ b/ImperialCommander2/Assets/Resources/SagaMissions/Jabba/JABBA5.json
@@ -1218,13 +1218,6 @@
           "displayName": "Modify Credits"
         },
         {
-          "customMissionID": "",
-          "missionID": "jabba11",
-          "GUID": "49f876b5-3d2d-4218-bcb0-48db9b66bc3a",
-          "eventActionType": 27,
-          "displayName": "Set Next Mission"
-        },
-        {
           "theText": "Are there three or more spice barrels on the Spicer's stockpile?",
           "includeCancel": false,
           "buttonList": [
@@ -1287,13 +1280,6 @@
           "GUID": "a99ee6f5-0868-4ae9-a260-1fdd90ea41d5",
           "eventActionType": 25,
           "displayName": "Modify Credits"
-        },
-        {
-          "customMissionID": "",
-          "missionID": "jabba11",
-          "GUID": "43f614ec-80d8-4d32-b268-9978dc98062b",
-          "eventActionType": 27,
-          "displayName": "Set Next Mission"
         },
         {
           "theText": "Are there three or more spice barrels on the Rebel stockpile?",

--- a/ImperialCommander2/Assets/Resources/SagaMissions/Jabba/JABBA8.json
+++ b/ImperialCommander2/Assets/Resources/SagaMissions/Jabba/JABBA8.json
@@ -1064,13 +1064,6 @@
           "displayName": "Modify Credits"
         },
         {
-          "customMissionID": "",
-          "missionID": "jabba11",
-          "GUID": "54d62592-8d68-4ca6-99a2-2b60f34ba112",
-          "eventActionType": 27,
-          "displayName": "Set Next Mission"
-        },
-        {
           "theText": "Is there only 1 healthy hero?",
           "includeCancel": false,
           "buttonList": [
@@ -1133,13 +1126,6 @@
           "GUID": "02d5488a-95c4-43df-87db-b37a244e127c",
           "eventActionType": 25,
           "displayName": "Modify Credits"
-        },
-        {
-          "customMissionID": "",
-          "missionID": "jabba11",
-          "GUID": "3323ec3a-c8cd-4857-b174-03c02964f311",
-          "eventActionType": 27,
-          "displayName": "Set Next Mission"
         },
         {
           "triggerList": [


### PR DESCRIPTION
Hi,
Please reject/close this PR if you think it's not appropriate.

In short: I played a Jabba campaign and we got sidetracked by the fact that a story mission was automatically filled. Indeed, we forgot that we actually had the choice between 2 Story missions because of the mission automatically filled.

I _feel_ that when players have the choice between multiple story missions, the app shouldn't automatically select one.

Of course, I let you (@GlowPuff) and @Noldorion decide if this idea is appropriate or not.
In case not, of course, please reject/close this PR.
In case it is, this PR is removing automatic mission selection for the few missions (4) ending up asking players to places multiple Story missions in play.

Cheers,
ilu