### PR TITLE
Fixing Dewback Rider instructions

### DIFF
--- a/ImperialCommander2/Assets/Resources/Languages/En/instructions.json
+++ b/ImperialCommander2/Assets/Resources/Languages/En/instructions.json
@@ -369,7 +369,7 @@
 				"instruction": [
 					"{Q} Move 3 to attack {R1}.",
 					"{Q}{A} Move 8 to attack {R1}.",
-					"{A} The closest Rebel within 2 spaces suffers 1 {H} and becomes <color=\"red\">Weakened</color>.",
+					"{A} SHOCK LANCE: The closest Rebel within 2 spaces suffers 1 {H} and becomes <color=\"red\">Weakened</color>.",
 					"{A} Move 5 to reposition 2.",
 					"{A} Move 5 to reposition 2.",
 				]

--- a/ImperialCommander2/Assets/Resources/Languages/Fr/instructions.json
+++ b/ImperialCommander2/Assets/Resources/Languages/Fr/instructions.json
@@ -369,7 +369,7 @@
         "instruction": [
           "{Q} Déplacement de 3 pour attaquer {R1}.",
           "{Q}{A} Déplacement de 8 pour attaquer {R1}.",
-          "{A} Le Rebelle le plus proche à 2 cases ou moins subit 1 {H} et devient <color=\"red\">Affaibli</color>.",
+          "{A} LANCE PARALYSANTE : Le Rebelle le plus proche à 2 cases ou moins subit 1 {H} et devient <color=\"red\">Affaibli</color>.",
           "{A} Déplacement de 5 pour se repositionner à 2.",
           "{A} Déplacement de 5 pour se repositionner à 2."
         ]

--- a/ImperialCommander2/Assets/Resources/Languages/Fr/instructions.json
+++ b/ImperialCommander2/Assets/Resources/Languages/Fr/instructions.json
@@ -369,7 +369,7 @@
         "instruction": [
           "{Q} Déplacement de 3 pour attaquer {R1}.",
           "{Q}{A} Déplacement de 8 pour attaquer {R1}.",
-          "{A} LANCE PARALYSANTE : Le Rebelle le plus proche à 2 cases ou moins subit 1 {H} et devient <color=\"red\">Affaibli</color>.",
+          "{A} LANCE PARALYSANTE : Le Rebelle le plus proche à 2 cases ou moins subit 1 {H} et devient <color=\"red\">Affaibli</color>.",
           "{A} Déplacement de 5 pour se repositionner à 2.",
           "{A} Déplacement de 5 pour se repositionner à 2."
         ]


### PR DESCRIPTION
Ability name "SHOCK LANCE:" is missing from Dewback Rider instructions.

1 of the dewback rider bonus effects is mentioning this ability name, hence why it needs to be added to the instructions:
https://github.com/GlowPuff/ImperialCommander2/blob/bf899b0866435be75644233fc2ca9928bde223a8/ImperialCommander2/Assets/Resources/Languages/En/bonuseffects.json#L77C4-L77C100