### PR TITLE
Adding missing "Elite" to  Shapeshifters and Tinkerers in instructions.json

### DIFF
--- a/ImperialCommander2/Assets/Resources/Languages/En/instructions.json
+++ b/ImperialCommander2/Assets/Resources/Languages/En/instructions.json
@@ -241,7 +241,7 @@
 		],
 	},
 	{
-		"instName": "Clawdite Shapeshifter",
+		"instName": "Clawdite Shapeshifter (Elite)",
 		"instID": "DG055",
 		"content": [
 			{
@@ -1359,7 +1359,7 @@
 		],
 	},
 	{
-		"instName": "Ugnaught Tinkerer",
+		"instName": "Ugnaught Tinkerer (Elite)",
 		"instID": "DG032",
 		"content": [
 			{

--- a/ImperialCommander2/Assets/Resources/Languages/Fr/instructions.json
+++ b/ImperialCommander2/Assets/Resources/Languages/Fr/instructions.json
@@ -241,7 +241,7 @@
     ]
   },
   {
-    "instName": "Changeant Clawdite",
+    "instName": "Changeant Clawdite (Élite)",
     "instID": "DG055",
     "content": [
       {


### PR DESCRIPTION
Adding missing "Elite" to  Shapeshifters and Tinkerers in instructions.json