### PR TITLE
Fixing event text to match proper droid color in Lothal5

### DIFF
--- a/ImperialCommander2/Assets/Resources/SagaMissions/Lothal/LOTHAL5.json
+++ b/ImperialCommander2/Assets/Resources/SagaMissions/Lothal/LOTHAL5.json
@@ -1497,7 +1497,7 @@
           "surges": "",
           "bonuses": "",
           "keywords": "",
-          "abilities": "BATTLE DROID: Once during their activation, a hero can command the blue battle droid. That hero may push the battle droid up to 3 spaces. Then, they may choose a figure within 3 spaces and in line of sight of the battle droid and roll 1 blue die. That figure suffers {H} equal to the {H}  results. Each battle droid can be commanded once per round.",
+          "abilities": "BATTLE DROID: Once during their activation, a hero can command the red battle droid. That hero may push the battle droid up to 3 spaces. Then, they may choose a figure within 3 spaces and in line of sight of the battle droid and roll 1 blue die. That figure suffers {H} equal to the {H}  results. Each battle droid can be commanded once per round.",
           "groupCost": 0,
           "groupRedeployCost": 0,
           "groupSize": 1,


### PR DESCRIPTION
Fixing event text to match proper droid color in Lothal5