### PR TITLE
Jabba3 - Fixing custom "Gamorrean Guards" attack type

### DIFF
--- a/ImperialCommander2/Assets/Resources/SagaMissions/Jabba/JABBA3.json
+++ b/ImperialCommander2/Assets/Resources/SagaMissions/Jabba/JABBA3.json
@@ -736,7 +736,7 @@
         {
           "customType": 1,
           "iconType": 2,
-          "attackType": 0,
+          "attackType": 1,
           "deploymentOutlineColor": null,
           "thumbnailGroupImperial": "DG041",
           "thumbnailGroupRebel": "A001",


### PR DESCRIPTION
Fixing custom group "Custom Deployment: Gamorrean Guards" which was wrongly set to use Ranged attack while it should be Melee.