### PR TITLE
Fixing "Rebel Saboteurs" wrong double numbers in Instructions

### DIFF
--- a/ImperialCommander2/Assets/Resources/Languages/De/DeploymentGroups/allies.json
+++ b/ImperialCommander2/Assets/Resources/Languages/De/DeploymentGroups/allies.json
@@ -59,7 +59,7 @@
 			"+2 Zielsicherheit"
 		],
 		"surges": [
-			"{B}: Durchschlagen 2 1",
+			"{B}: Durchschlagen 1",
 			"{B}: Betäuben",
 			"{B}: Explosion 1 {H}"
 		],
@@ -697,7 +697,7 @@
 		"surges": [
 			"{B}: Durchschlagen 2",
 			"{B}: Betäuben",
-			"{B}: Explosion 2 1 {H}"
+			"{B}: Explosion 1 {H}"
 		],
 		"abilities": [
 			{

--- a/ImperialCommander2/Assets/Resources/Languages/En/DeploymentGroups/allies.json
+++ b/ImperialCommander2/Assets/Resources/Languages/En/DeploymentGroups/allies.json
@@ -59,7 +59,7 @@
 			"+2 Accuracy"
 		],
 		"surges": [
-			"{B}: Pierce 2 1",
+			"{B}: Pierce 1",
 			"{B}: Stun",
 			"{B}: Blast 1 {H}"
 		],
@@ -697,7 +697,7 @@
 		"surges": [
 			"{B}: Pierce 2",
 			"{B}: Stun",
-			"{B}: Blast 2 1 {H}"
+			"{B}: Blast 1 {H}"
 		],
 		"abilities": [
 			{

--- a/ImperialCommander2/Assets/Resources/Languages/Es/DeploymentGroups/allies.json
+++ b/ImperialCommander2/Assets/Resources/Languages/Es/DeploymentGroups/allies.json
@@ -59,7 +59,7 @@
 			"+2 Precisión"
 		],
 		"surges": [
-			"{B}: Perforante 2 1",
+			"{B}: Perforante 1",
 			"{B}: Aturdimiento",
 			"{B}: Explosión 1 {H}"
 		],

--- a/ImperialCommander2/Assets/Resources/Languages/Hu/DeploymentGroups/allies.json
+++ b/ImperialCommander2/Assets/Resources/Languages/Hu/DeploymentGroups/allies.json
@@ -59,7 +59,7 @@
 			"+2 Accuracy"
 		],
 		"surges": [
-			"{B}: Pierce 2 1",
+			"{B}: Pierce 1",
 			"{B}: Stun",
 			"{B}: Blast 1 {H}"
 		],
@@ -697,7 +697,7 @@
 		"surges": [
 			"{B}: Pierce 2",
 			"{B}: Stun",
-			"{B}: Blast 2 1 {H}"
+			"{B}: Blast 1 {H}"
 		],
 		"abilities": [
 			{

--- a/ImperialCommander2/Assets/Resources/Languages/It/DeploymentGroups/allies.json
+++ b/ImperialCommander2/Assets/Resources/Languages/It/DeploymentGroups/allies.json
@@ -59,7 +59,7 @@
 			"+2 Precisione"
 		],
 		"surges": [
-			"{B}: Perforante 2 1",
+			"{B}: Perforante 1",
 			"{B}: Stordito",
 			"{B}: Esplosione 1 {H}"
 		],

--- a/ImperialCommander2/Assets/Resources/Languages/No/DeploymentGroups/allies.json
+++ b/ImperialCommander2/Assets/Resources/Languages/No/DeploymentGroups/allies.json
@@ -59,7 +59,7 @@
 			"+2 Accuracy"
 		],
 		"surges": [
-			"{B}: Pierce 2 1",
+			"{B}: Pierce 1",
 			"{B}: Stun",
 			"{B}: Blast 1 {H}"
 		],
@@ -697,7 +697,7 @@
 		"surges": [
 			"{B}: Pierce 2",
 			"{B}: Stun",
-			"{B}: Blast 2 1 {H}"
+			"{B}: Blast 1 {H}"
 		],
 		"abilities": [
 			{

--- a/ImperialCommander2/Assets/Resources/Languages/Pl/DeploymentGroups/allies.json
+++ b/ImperialCommander2/Assets/Resources/Languages/Pl/DeploymentGroups/allies.json
@@ -59,7 +59,7 @@
 			"+2 celności"
 		],
 		"surges": [
-			"{B}: Przebicie 2 1",
+			"{B}: Przebicie 1",
 			"{B}: Ogłuszenie",
 			"{B}: Wybuch 1 {H}"
 		],


### PR DESCRIPTION
As discussed with @Noldorion in BGG geekmail.

Fixing "Rebel Saboteurs" wrong double numbers in Instructions