### PR TITLE
small corrections in English mission card texts for core 13, 18, 23, 26, and 30

### DIFF
--- a/ImperialCommander2/Assets/Resources/Languages/En/MissionCardText/core.json
+++ b/ImperialCommander2/Assets/Resources/Languages/En/MissionCardText/core.json
@@ -330,7 +330,7 @@
 		"descriptionText": "<i>The Rebellion's message of hope draws many to the cause. Who better to spearhead the recruiting effort than the man behind the Death Star's destruction, Luke Skywalker?\nHowever, what makes him an ideal figure of inspiration also makes him a priority target for Imperial reprisal...</i>",
 		"bonusText": "",
 		"heroText": "",
-		"allyText": "",
+		"allyText": "Luke Skywalker (Hero of the Rebellion)",
 		"villainText": "",
 		"tagsText": [
 			"Tatooine",

--- a/ImperialCommander2/Assets/Resources/Languages/En/MissionCardText/core.json
+++ b/ImperialCommander2/Assets/Resources/Languages/En/MissionCardText/core.json
@@ -172,7 +172,7 @@
 			"Wilderness"
 			],
 		"expansionText": "Core Game",
-		"rebelRewardText": "",
+		"rebelRewardText": "\"Veteran Prowess\" Reward Card",
 		"imperialRewardText": ""
  	},
  	{
@@ -254,7 +254,7 @@
 			"Wastes"
 			],
 		"expansionText": "Core Game",
-		"rebelRewardText": "Luke Skywalker (Hero of the Rebellion) ally",
+		"rebelRewardText": "\"Luke Skywalker (Hero of the Rebellion)\" ally",
 		"imperialRewardText": ""
  	},
  	{
@@ -330,7 +330,7 @@
 		"descriptionText": "<i>The Rebellion's message of hope draws many to the cause. Who better to spearhead the recruiting effort than the man behind the Death Star's destruction, Luke Skywalker?\nHowever, what makes him an ideal figure of inspiration also makes him a priority target for Imperial reprisal...</i>",
 		"bonusText": "",
 		"heroText": "",
-		"allyText": "Luke Skywalker (Hero of the Rebellion)",
+		"allyText": "",
 		"villainText": "",
 		"tagsText": [
 			"Tatooine",
@@ -376,7 +376,7 @@
  	{
 		"id": "Core26",
 		"name": "The Spice Job",
-		"descriptionText": "<i>Han Solo’ debts have become a prime concern for his companion. Against Han’s wishes, Chewbacca has a task that he hopes will reduce the Hutts’ attention toward Han.\nIf successful, the job may earn some credits and distract the Hutts, allowings Han a time of respite, however brief...</i>",
+		"descriptionText": "<i>Han Solo's debts have become a prime concern for his companion. Against Han's wishes, Chewbacca has a task that he hopes will reduce the Hutts' attention toward Han.\nIf successful, the job may earn some credits and distract the Hutts, allowings Han a time of respite, however brief...</i>",
 		"bonusText": "",
 		"heroText": "",
 		"allyText": "Chewbacca (Loyal Wookiee)",

--- a/ImperialCommander2/Assets/Resources/MissionData/core.json
+++ b/ImperialCommander2/Assets/Resources/MissionData/core.json
@@ -327,7 +327,7 @@
 		"tags": ["Corellia", "Imperial", "Wastes"],
 		"page": 22,
 		"timePeriod": [],
-		"influenceCost": 0
+		"influenceCost": 4
  	},
  	{
 		"id": "Core31",


### PR DESCRIPTION
As part of my work on my own app (Imperial Assault Deck Manager, which - among other things - allowed me to quickly toggle between scanned images and the IC2 texts), I've noticed a few small mistakes in the card texts & info for 4 core missions:

- Core13: rebelRewardText was missing (this is also still the case for the Fr, Hu, and No translations - but I don't know the name of the reward card in those languages)
- Core18: the reward had some quotation marks missing
- Core23: The reward was incorrect, should be "Ways of the Force" (this was already previously fixed for English & French, but it's still incorrect for Es, Hu, and No)
- Core26: some incorrect apostrophes
- Core30: the influence cost was 0, but should be 4

Thanks so much for this awesome app!