### PR TITLE
small corrections in French mission card text for core 13

### DIFF
--- a/ImperialCommander2/Assets/Resources/Languages/Fr/MissionCardText/core.json
+++ b/ImperialCommander2/Assets/Resources/Languages/Fr/MissionCardText/core.json
@@ -172,7 +172,7 @@
       "Région sauvage"
     ],
     "expansionText": "Jeu de base",
-    "rebelRewardText": "",
+    "rebelRewardText": "Carte récompense « Prouesse du vétéran »",
     "imperialRewardText": ""
   },
   {


### PR DESCRIPTION
Fixing Fr typo in Core13, reported in https://github.com/GlowPuff/ImperialCommander2/pull/150