### PR TITLE
Standardize dropdown chevrons via reusable prefab + width fixes (issue #171)

### DIFF
--- a/ImperialCommander2/Assets/Prefabs/Chevron.prefab
+++ b/ImperialCommander2/Assets/Prefabs/Chevron.prefab
@@ -1,0 +1,77 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &7024376267980125033
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4568053563366677055}
+  - component: {fileID: 6515664457534050962}
+  - component: {fileID: 7128346826970446763}
+  m_Layer: 5
+  m_Name: Chevron
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4568053563366677055
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7024376267980125033}
+  m_LocalRotation: {x: -0, y: -0, z: -0.7071066, w: 0.70710695}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: -90}
+  m_AnchorMin: {x: 1, y: 0.5}
+  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchoredPosition: {x: -50, y: 0}
+  m_SizeDelta: {x: 40, y: 40}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6515664457534050962
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7024376267980125033}
+  m_CullTransparentMesh: 1
+--- !u!114 &7128346826970446763
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7024376267980125033}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 37d28b141b602ba42b7526f30b129d35, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1

--- a/ImperialCommander2/Assets/Prefabs/Chevron.prefab.meta
+++ b/ImperialCommander2/Assets/Prefabs/Chevron.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 2dc46a5ce846b47d2b884a715804d9e5
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ImperialCommander2/Assets/Scenes/Campaign.unity
+++ b/ImperialCommander2/Assets/Scenes/Campaign.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.00038935457, g: 0.044618133, b: 0.038814366, a: 1}
+  m_IndirectSpecularColor: {r: 0.00041144507, g: 0.04463131, b: 0.0387953, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -672,7 +672,7 @@ RectTransform:
   - {fileID: 168473805}
   - {fileID: 1062896580}
   m_Father: {fileID: 565269591}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 0}
@@ -2489,7 +2489,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 565269591}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0.5}
   m_AnchorMax: {x: 1, y: 0.5}
@@ -2570,6 +2570,125 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1001 &233407623
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 565269591}
+    m_Modifications:
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 40
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 40
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.70710695
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.7071066
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -50
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -90
+      objectReference: {fileID: 0}
+    - target: {fileID: 7024376267980125033, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_Name
+      value: Chevron
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 2dc46a5ce846b47d2b884a715804d9e5, type: 3}
 --- !u!1 &247959258
 GameObject:
   m_ObjectHideFlags: 0
@@ -3965,7 +4084,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 565269591}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: -90}
   m_AnchorMin: {x: 1, y: 0.5}
   m_AnchorMax: {x: 1, y: 0.5}
@@ -4586,6 +4705,12 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 8300859190810787415, guid: 1571b09e85d3f284595c28ead00913da,
     type: 3}
   m_PrefabInstance: {fileID: 321065205}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &331649902 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+    type: 3}
+  m_PrefabInstance: {fileID: 233407623}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &353640168
 GameObject:
@@ -6402,7 +6527,7 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 531411025}
   m_HandleRect: {fileID: 531411024}
   m_Direction: 2
-  m_Value: 0
+  m_Value: 1
   m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:
@@ -7705,6 +7830,7 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
+  - {fileID: 331649902}
   - {fileID: 1912224563}
   - {fileID: 317078554}
   - {fileID: 206754076}
@@ -11887,7 +12013,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 7.5000305, y: 0}
+  m_AnchoredPosition: {x: 7.500061, y: 0}
   m_SizeDelta: {x: -14.999954, y: -30}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &999627575
@@ -15008,7 +15134,7 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 1926341755}
   m_HandleRect: {fileID: 1926341754}
   m_Direction: 2
-  m_Value: 0
+  m_Value: 1
   m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:
@@ -21245,7 +21371,7 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 1873870850}
   m_HandleRect: {fileID: 1873870849}
   m_Direction: 2
-  m_Value: 0
+  m_Value: 1
   m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:
@@ -21769,7 +21895,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 565269591}
-  m_RootOrder: 0
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -25972,7 +26098,7 @@ PrefabInstance:
     - target: {fileID: 69210028858027234, guid: a5725bae479ea2544a2e1e429bd7cc5b,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 723.66675
+      value: 822.7647
       objectReference: {fileID: 0}
     - target: {fileID: 69210028858027234, guid: a5725bae479ea2544a2e1e429bd7cc5b,
         type: 3}
@@ -26072,7 +26198,7 @@ PrefabInstance:
     - target: {fileID: 4843218275750989084, guid: a5725bae479ea2544a2e1e429bd7cc5b,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 377.1667
+      value: 401.94116
       objectReference: {fileID: 0}
     - target: {fileID: 4843218275750989084, guid: a5725bae479ea2544a2e1e429bd7cc5b,
         type: 3}
@@ -26172,7 +26298,7 @@ PrefabInstance:
     - target: {fileID: 6364341838366083404, guid: a5725bae479ea2544a2e1e429bd7cc5b,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 621.50006
+      value: 695.82355
       objectReference: {fileID: 0}
     - target: {fileID: 6364341838366083404, guid: a5725bae479ea2544a2e1e429bd7cc5b,
         type: 3}
@@ -26192,7 +26318,7 @@ PrefabInstance:
     - target: {fileID: 6364341838370295271, guid: a5725bae479ea2544a2e1e429bd7cc5b,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 554.3334
+      value: 603.8824
       objectReference: {fileID: 0}
     - target: {fileID: 6364341838370295271, guid: a5725bae479ea2544a2e1e429bd7cc5b,
         type: 3}
@@ -26212,7 +26338,7 @@ PrefabInstance:
     - target: {fileID: 6364341838878418121, guid: a5725bae479ea2544a2e1e429bd7cc5b,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 825.83344
+      value: 949.7059
       objectReference: {fileID: 0}
     - target: {fileID: 6364341838878418121, guid: a5725bae479ea2544a2e1e429bd7cc5b,
         type: 3}

--- a/ImperialCommander2/Assets/Scenes/Title.unity
+++ b/ImperialCommander2/Assets/Scenes/Title.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.00038935457, g: 0.044618133, b: 0.038814366, a: 1}
+  m_IndirectSpecularColor: {r: 0.00041144507, g: 0.04463131, b: 0.0387953, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -9764,7 +9764,7 @@ RectTransform:
   - {fileID: 1254319736}
   - {fileID: 1721682129}
   m_Father: {fileID: 648609971}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 0}
@@ -13776,6 +13776,125 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 309260524}
   m_CullTransparentMesh: 0
+--- !u!1001 &309830102
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 648609971}
+    m_Modifications:
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 24
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 24
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.70710695
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.7071066
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -30
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -90
+      objectReference: {fileID: 0}
+    - target: {fileID: 7024376267980125033, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_Name
+      value: Chevron
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 2dc46a5ce846b47d2b884a715804d9e5, type: 3}
 --- !u!1 &314532015
 GameObject:
   m_ObjectHideFlags: 0
@@ -17047,7 +17166,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 960393291}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0.5}
   m_AnchorMax: {x: 1, y: 0.5}
@@ -25351,6 +25470,7 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
+  - {fileID: 1995247847}
   - {fileID: 668181683}
   - {fileID: 1061923083}
   - {fileID: 1980140434}
@@ -25360,7 +25480,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 200, y: 64}
+  m_SizeDelta: {x: 260, y: 64}
   m_Pivot: {x: 1, y: 1}
 --- !u!114 &618764991
 MonoBehaviour:
@@ -26632,6 +26752,7 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
+  - {fileID: 906685509}
   - {fileID: 2127493318}
   - {fileID: 974662264}
   - {fileID: 218242506}
@@ -26641,7 +26762,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 190, y: 64}
+  m_SizeDelta: {x: 222, y: 64}
   m_Pivot: {x: 1, y: 1}
 --- !u!114 &648609972
 MonoBehaviour:
@@ -26972,7 +27093,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 64, y: 64}
+  m_SizeDelta: {x: 32, y: 64}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &654429615
 GameObject:
@@ -27558,12 +27679,12 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 618764990}
-  m_RootOrder: 0
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: -0.5}
-  m_SizeDelta: {x: -20, y: -13}
+  m_AnchoredPosition: {x: -14, y: -0.5}
+  m_SizeDelta: {x: -68, y: -13}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &668181684
 MonoBehaviour:
@@ -34045,7 +34166,7 @@ RectTransform:
   - {fileID: 629040989}
   - {fileID: 549978445}
   m_Father: {fileID: 960393291}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 0}
@@ -37290,6 +37411,12 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 906459748}
   m_CullTransparentMesh: 1
+--- !u!224 &906685509 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+    type: 3}
+  m_PrefabInstance: {fileID: 309830102}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &907685366
 GameObject:
   m_ObjectHideFlags: 0
@@ -39150,6 +39277,7 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1.0000306, y: 1.0000306, z: 1.0000306}
   m_Children:
+  - {fileID: 1646109235}
   - {fileID: 2034011148}
   - {fileID: 405241537}
   - {fileID: 834142980}
@@ -39542,7 +39670,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 648609971}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 45}
   m_AnchorMin: {x: 1, y: 0.5}
   m_AnchorMax: {x: 1, y: 0.5}
@@ -43601,7 +43729,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 618764990}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0.5}
   m_AnchorMax: {x: 1, y: 0.5}
@@ -51558,6 +51686,125 @@ MonoBehaviour:
           m_BoolArgument: 0
         m_CallState: 2
   m_IsOn: 0
+--- !u!1001 &1277469128
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 960393291}
+    m_Modifications:
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 40
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 40
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.70710695
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.7071066
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -50
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -90
+      objectReference: {fileID: 0}
+    - target: {fileID: 7024376267980125033, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_Name
+      value: Chevron
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 2dc46a5ce846b47d2b884a715804d9e5, type: 3}
 --- !u!1 &1280487934
 GameObject:
   m_ObjectHideFlags: 0
@@ -61580,7 +61827,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -109, y: -50}
+  m_AnchoredPosition: {x: -170, y: -50}
   m_SizeDelta: {x: 940, y: 64}
   m_Pivot: {x: 1, y: 1}
 --- !u!114 &1524349716
@@ -66456,6 +66703,12 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1645549521}
   m_CullTransparentMesh: 1
+--- !u!224 &1646109235 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+    type: 3}
+  m_PrefabInstance: {fileID: 1277469128}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1646315560
 GameObject:
   m_ObjectHideFlags: 0
@@ -79783,7 +80036,7 @@ RectTransform:
   - {fileID: 251500157}
   - {fileID: 588095903}
   m_Father: {fileID: 618764990}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 0}
@@ -80367,6 +80620,146 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1989333900}
   m_CullTransparentMesh: 0
+--- !u!1001 &1995247846
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 618764990}
+    m_Modifications:
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 24
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 24
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.70710695
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.7071066
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -30
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -90
+      objectReference: {fileID: 0}
+    - target: {fileID: 7024376267980125033, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_Name
+      value: Chevron
+      objectReference: {fileID: 0}
+    - target: {fileID: 7128346826970446763, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+        type: 3}
+      propertyPath: m_RaycastPadding.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 2dc46a5ce846b47d2b884a715804d9e5, type: 3}
+--- !u!224 &1995247847 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 4568053563366677055, guid: 2dc46a5ce846b47d2b884a715804d9e5,
+    type: 3}
+  m_PrefabInstance: {fileID: 1995247846}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1995485765
 GameObject:
   m_ObjectHideFlags: 0
@@ -82359,7 +82752,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 960393291}
-  m_RootOrder: 0
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -86558,12 +86951,12 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 648609971}
-  m_RootOrder: 0
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: -0.5}
-  m_SizeDelta: {x: -20, y: -13}
+  m_AnchoredPosition: {x: -13, y: -0.5}
+  m_SizeDelta: {x: -66, y: -13}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2127493319
 MonoBehaviour:
@@ -86615,9 +87008,9 @@ MonoBehaviour:
   m_fontSize: 30
   m_fontSizeBase: 30
   m_fontWeight: 400
-  m_enableAutoSizing: 0
+  m_enableAutoSizing: 1
   m_fontSizeMin: 18
-  m_fontSizeMax: 72
+  m_fontSizeMax: 30
   m_fontStyle: 0
   m_HorizontalAlignment: 2
   m_VerticalAlignment: 512


### PR DESCRIPTION
Fixes #171.
I have unified the dropdown affordance across screens and prevented label text from overlapping the chevron icon.
### What changed

- Campaign scene
-- Converted the existing chevron GameObject into a reusable prefab (right-aligned, non-interactive icon).
-- Replaced the scene instance with the new prefab.
- Title scene (landing)
-- Reused the chevron prefab in three places:
-- Tutorial dropdown
-- Language dropdown
-- New Campaign modal → Campaign selector dropdown
- Layout/UX
-- Adjusted label width/padding so longer values don’t overlap the chevron

### Why
Consistent “this opens a list” affordance across screens.
Avoids text-over-icon collisions with longer language names or options.
### Testing
Editor Play Mode:
Open Title scene → Tutorial and Language dropdowns: chevron visible, no overlap with longer values (e.g. “Portuguese”, other locales).
<img width="2838" height="448" alt="image" src="https://github.com/user-attachments/assets/b178073d-2423-4869-b73b-ae44d8846e83" />
<img width="2828" height="428" alt="image" src="https://github.com/user-attachments/assets/a7d31c2c-399b-41c4-87b1-491ccf7e7179" />
<img width="2822" height="328" alt="image" src="https://github.com/user-attachments/assets/f9e6e924-26aa-423a-b80f-9bf0af2e0a84" />
<img width="2836" height="304" alt="image" src="https://github.com/user-attachments/assets/a9ea59e0-dedf-4c30-8d32-39107f182983" />

Open New Campaign modal → Campaign selector: chevron visible and aligned; no overlap.
<img width="972" height="966" alt="image" src="https://github.com/user-attachments/assets/fc51d63f-f16f-4bd7-9555-a2f3feb88f32" />

Buttons remain fully clickable (chevron does not block input).
### How to verify
Launch Title scene; check Tutorial/Language buttons (closed and open states).
Open New Campaign modal; check Campaign selector.
Switch languages to longer names and confirm labels don’t collide with the chevron.
### Notes
No code logic changes; prefab + layout updates only.
