### PR TITLE
Add .DS_Store to .gitignore to reduce macOS noise (issue #173)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ crashlytics-build.properties
 # Temporary auto-generated Assets
 **/[Aa]ssets/[Ss]treamingAssets/
 **/[Aa]ssets/[Ss]treamingAssets.meta
+
+# macOS Finder files
+.DS_Store


### PR DESCRIPTION
Fixes #173.
This PR adds `.DS_Store` to the `.gitignore` file to prevent macOS Finder metadata files from showing up as untracked files in Git.

- `.DS_Store` files are automatically created by macOS in folders and are not part of the project.
- Including them in `.gitignore` reduces noise in `git status` and keeps commits clean.
- No project functionality is affected by this change.

This small addition will make contributing from macOS smoother and cleaner.